### PR TITLE
feat: show "Updated <date>" data freshness indicator in header

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -30,6 +30,12 @@ import { NpmVersionHeatmapCard } from './Card/npm/NpmVersionHeatmapCard/NpmVersi
 
 const MIN_SCREEN_SIZE = 920;
 
+const DATA_AS_OF_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
 interface AppProps {
   style?: React.CSSProperties;
 }
@@ -128,9 +134,15 @@ export default function App({ style }: AppProps) {
     );
   }, [isLoading]);
 
+  const dataAsOf = useMemo(() => {
+    if (isLoading) return undefined;
+    const date = dataRef.current.latestDataDate;
+    return date ? DATA_AS_OF_FORMATTER.format(date) : undefined;
+  }, [isLoading]);
+
   const content = isLoading ? null : (
     <div className="app__content">
-      <Header activeTab={activeTab} onTabChange={setActiveTab} />
+      <Header activeTab={activeTab} onTabChange={setActiveTab} dataAsOf={dataAsOf} />
       {activeTab === 'github' ? githubContent : npmContent}
       <Footer />
     </div>

--- a/src/components/Layout/Header.css
+++ b/src/components/Layout/Header.css
@@ -15,6 +15,17 @@
   margin: 0;
 }
 
+.header__right {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.header__updated {
+  font-size: 12px;
+  color: var(--color-foreground-light);
+}
+
 .header__tabs {
   display: flex;
   position: relative;

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -6,9 +6,10 @@ export type MetricsTab = 'github' | 'npm';
 interface HeaderProps {
   activeTab: MetricsTab;
   onTabChange: (tab: MetricsTab) => void;
+  dataAsOf?: string;
 }
 
-export const Header: FC<HeaderProps> = memo(({ activeTab, onTabChange }) => {
+export const Header: FC<HeaderProps> = memo(({ activeTab, onTabChange, dataAsOf }) => {
   const tabsRef = useRef<HTMLElement>(null);
   const githubRef = useRef<HTMLButtonElement>(null);
   const npmRef = useRef<HTMLButtonElement>(null);
@@ -33,25 +34,28 @@ export const Header: FC<HeaderProps> = memo(({ activeTab, onTabChange }) => {
     <header className="header">
       <div className="header__content">
         <h1>Metrics</h1>
-        <nav className="header__tabs" ref={tabsRef}>
-          <button
-            type="button"
-            ref={githubRef}
-            className={`header__tab${activeTab === 'github' ? ' header__tab--active' : ''}`}
-            onClick={() => onTabChange('github')}
-          >
-            GitHub
-          </button>
-          <button
-            type="button"
-            ref={npmRef}
-            className={`header__tab${activeTab === 'npm' ? ' header__tab--active' : ''}`}
-            onClick={() => onTabChange('npm')}
-          >
-            npm
-          </button>
-          <div className="header__bar" style={barStyle} />
-        </nav>
+        <div className="header__right">
+          {dataAsOf ? <span className="header__updated">Updated {dataAsOf}</span> : null}
+          <nav className="header__tabs" ref={tabsRef}>
+            <button
+              type="button"
+              ref={githubRef}
+              className={`header__tab${activeTab === 'github' ? ' header__tab--active' : ''}`}
+              onClick={() => onTabChange('github')}
+            >
+              GitHub
+            </button>
+            <button
+              type="button"
+              ref={npmRef}
+              className={`header__tab${activeTab === 'npm' ? ' header__tab--active' : ''}`}
+              onClick={() => onTabChange('npm')}
+            >
+              npm
+            </button>
+            <div className="header__bar" style={barStyle} />
+          </nav>
+        </div>
       </div>
     </header>
   );

--- a/src/models/Data.ts
+++ b/src/models/Data.ts
@@ -683,6 +683,24 @@ export class Data {
   get npmPackages(): PackageStats[] {
     return this.#npmAccountStats?.packages ?? [];
   }
+
+  // Latest date covered by the synced data. Date keys are zero-padded
+  // `YYYY-MM-DD`, so lexicographic comparison is already chronological.
+  // Combines both sources by taking the oldest of their latest dates, so the
+  // value never overstates how fresh the least up-to-date source is.
+  get latestDataDate(): Date | null {
+    const maxKey = (keys: string[]): string | null =>
+      keys.length === 0 ? null : keys.reduce((a, b) => (a > b ? a : b));
+
+    const githubLatest = maxKey(Object.keys(this.#githubCommitsPerDate));
+    const npmLatest = maxKey([...Object.keys(this.#npmDownloadsPerDate), ...Object.keys(this.#npmVersionsPerDate)]);
+
+    const candidates = [githubLatest, npmLatest].filter((key): key is string => key !== null);
+    if (candidates.length === 0) return null;
+    const oldestLatest = candidates.reduce((a, b) => (a < b ? a : b));
+
+    return new Date(`${oldestLatest}T00:00:00`);
+  }
 }
 
 export default Data;


### PR DESCRIPTION
## Summary

Adds a small **"Updated <date>"** caption in the page header (left of the GitHub/npm tabs) so visitors can see how fresh the displayed data is.

- **`src/models/Data.ts`** — new `latestDataDate` getter. Derives the latest date covered by the synced stats by taking the most recent date from each source (GitHub commits, npm downloads + versions) and returning the **oldest of the two**, so the label never overstates how fresh the least up-to-date source is. Date keys are zero-padded `YYYY-MM-DD`, so plain string comparison is already chronological. Returns `null` when no data is present.
- **`src/components/App.tsx`** — formats the date as e.g. `Jun 14, 2026` via `Intl.DateTimeFormat` and passes it to the header.
- **`src/components/Layout/Header.tsx` + `Header.css`** — renders `Updated <date>` as a muted caption. The tabs were wrapped in a new `header__right` container; the active-tab underline indicator is unaffected (still measured relative to `<nav>`). Caption is hidden when no date is available.

## Why "data content" instead of a sync timestamp

The stats JSON has no timestamp field and `raw.githubusercontent.com` doesn't expose `Last-Modified`, so the indicator reflects the **latest data point**, not literally when the sync job ran. On a day with no commits and no new npm downloads it can lag slightly. Exact sync time would require adding a `syncedAt` field to the `github-stats`/`npm-stats` repos (out of scope for this repo).

## Test plan

This project has no test framework (no `test` script); verified via the project's own checks:

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` (`tsc && vite build`) — succeeds
- [x] Browser check — header shows `Updated Jun 14, 2026`; switching GitHub <-> npm tabs keeps the caption in place and the active-tab underline repositions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)