### PR TITLE
Live ~username pages via metrics-api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist
 .next
 .playwright-mcp
 .vscode
+
+# Superpowers working docs (specs/plans) — local only
+docs/superpowers/

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "typescript": "^6.0.2",
-        "vite": "^8.0.8"
+        "vite": "^8.0.8",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -185,29 +186,6 @@
         "node": ">=14.21.3"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -218,6 +196,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
@@ -341,9 +326,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -361,9 +343,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -381,9 +360,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -401,9 +377,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -421,9 +394,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -441,9 +411,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -530,6 +497,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -539,6 +513,17 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3": {
@@ -825,6 +810,20 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -838,6 +837,7 @@
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -848,6 +848,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -888,6 +889,139 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/commander": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
@@ -896,6 +1030,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1221,6 +1362,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1322,6 +1464,33 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1639,6 +1808,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -1658,6 +1837,27 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1671,6 +1871,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1712,6 +1913,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1793,6 +1995,13 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1801,6 +2010,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1818,6 +2058,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -1855,6 +2105,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -1925,6 +2176,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome check src",
     "lint:fix": "biome check --write src",
+    "test": "vitest run",
     "deploy": "scripts/deploy.sh"
   },
   "keywords": [
@@ -39,6 +40,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "typescript": "^6.0.2",
-    "vite": "^8.0.8"
+    "vite": "^8.0.8",
+    "vitest": "^4.1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && cp dist/index.html dist/404.html",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "biome check src",

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -11,3 +11,13 @@
     opacity: 1;
   }
 }
+
+.app__error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 16px;
+  text-align: center;
+}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,11 +3,15 @@ import { Footer } from '@/components/Layout/Footer';
 import { Header, type MetricsTab } from '@/components/Layout/Header';
 import { Loading } from '@/components/Loading/Loading';
 import { Row, RowType } from '@/components/shared/Row';
+import { MetricsApiError } from '@/live/metricsApi';
 import Data from '@/models/Data';
+import { LiveData } from '@/models/LiveData';
+import type { MetricsData } from '@/models/MetricsData';
 import '@/style/index.css';
 import './App.css';
 
 // GitHub cards
+import { GithubContributionTotalsCard } from './Card/github/GithubContributionTotalsCard/GithubContributionTotalsCard';
 import { GithubDaytimeChartCard } from './Card/github/GithubDaytimeChartCard/GithubDaytimeChartCard';
 import { GithubFollowersCard } from './Card/github/GithubFollowersCard/GithubFollowersCard';
 import { GithubPopularReposCard } from './Card/github/GithubPopularReposCard/GithubPopularReposCard';
@@ -59,93 +63,148 @@ const syncViewport = () => {
 };
 
 export default function App({ style, liveUser }: AppProps) {
-  void liveUser;
-  const dataRef = useRef(new Data());
+  const dataRef = useRef<MetricsData | null>(null);
+  if (dataRef.current === null) {
+    dataRef.current = liveUser ? new LiveData(liveUser) : new Data();
+  }
+  const data = dataRef.current;
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<'not-found' | 'unavailable' | null>(null);
   const [activeTab, setActiveTab] = useState<MetricsTab>('github');
 
   useEffect(() => {
-    dataRef.current.fetchData().then(() => setIsLoading(false));
-  }, []);
+    data
+      .fetchData()
+      .then(() => setIsLoading(false))
+      .catch((error: unknown) => {
+        setLoadError(error instanceof MetricsApiError && error.kind === 'not-found' ? 'not-found' : 'unavailable');
+        setIsLoading(false);
+      });
+  }, [data]);
+
+  useEffect(() => {
+    if (liveUser) document.title = `Metrics · ${liveUser}`;
+  }, [liveUser]);
 
   useEffect(syncViewport, []);
 
   const githubContent = useMemo(() => {
     if (isLoading) return null;
+    if (liveUser) {
+      return (
+        <>
+          <Row
+            type={RowType.FIRST_THIRD}
+            first={<GithubUserCard data={data} />}
+            last={<GithubContributionTotalsCard data={data} />}
+          />
+          <Row>
+            <GithubYearChartCard data={data} />
+          </Row>
+          <Row>
+            <GithubYearHeatmapCard data={data} countLabel="Contributions" />
+          </Row>
+          <Row
+            type={RowType.LAST_THIRD}
+            first={<GithubWeekdayComparisonCard data={data} />}
+            last={<GithubFollowersCard data={data} />}
+          />
+          <Row>
+            <GithubPopularReposCard data={data} />
+          </Row>
+        </>
+      );
+    }
     return (
       <>
         <Row
           type={RowType.FIRST_THIRD}
-          first={<GithubUserCard data={dataRef.current} />}
-          last={<GithubTotalCountsCard data={dataRef.current} />}
+          first={<GithubUserCard data={data} />}
+          last={<GithubTotalCountsCard data={data} />}
         />
         <Row>
-          <GithubDaytimeChartCard data={dataRef.current} />
+          <GithubDaytimeChartCard data={data} />
         </Row>
         <Row>
-          <GithubWeekdayChartCard data={dataRef.current} />
+          <GithubWeekdayChartCard data={data} />
         </Row>
         <Row
           type={RowType.LAST_THIRD}
-          first={<GithubWeekdayComparisonCard data={dataRef.current} />}
-          last={<GithubVisibilityComparisionCard data={dataRef.current} />}
+          first={<GithubWeekdayComparisonCard data={data} />}
+          last={<GithubVisibilityComparisionCard data={data} />}
         />
         <Row>
-          <GithubYearChartCard data={dataRef.current} />
+          <GithubYearChartCard data={data} />
         </Row>
         <Row>
-          <GithubYearHeatmapCard data={dataRef.current} />
+          <GithubYearHeatmapCard data={data} />
         </Row>
         <Row
           type={RowType.LAST_THIRD}
-          first={<GithubPopularReposCard data={dataRef.current} />}
-          last={<GithubFollowersCard data={dataRef.current} />}
+          first={<GithubPopularReposCard data={data} />}
+          last={<GithubFollowersCard data={data} />}
         />
         <Row>
-          <GithubTimelineCard data={dataRef.current} />
+          <GithubTimelineCard data={data} />
         </Row>
       </>
     );
-  }, [isLoading]);
+  }, [isLoading, liveUser, data]);
 
   const npmContent = useMemo(() => {
     if (isLoading) return null;
     return (
       <>
-        <Row
-          type={RowType.FIRST_THIRD}
-          first={<NpmUserCard data={dataRef.current} />}
-          last={<NpmTotalCountsCard data={dataRef.current} />}
-        />
+        <Row type={RowType.FIRST_THIRD} first={<NpmUserCard data={data} />} last={<NpmTotalCountsCard data={data} />} />
         <Row>
-          <NpmPublishDaytimeCard data={dataRef.current} />
+          <NpmPublishDaytimeCard data={data} />
         </Row>
         <Row>
-          <NpmOrgDetailCard data={dataRef.current} />
+          <NpmOrgDetailCard data={data} />
         </Row>
         <Row>
-          <NpmOrgTimelineCard data={dataRef.current} />
+          <NpmOrgTimelineCard data={data} />
         </Row>
         <Row>
-          <NpmVersionHeatmapCard data={dataRef.current} />
+          <NpmVersionHeatmapCard data={data} />
         </Row>
         <Row>
-          <NpmOrganizationsCard data={dataRef.current} />
+          <NpmOrganizationsCard data={data} />
         </Row>
       </>
     );
-  }, [isLoading]);
+  }, [isLoading, data]);
 
   const dataAsOf = useMemo(() => {
     if (isLoading) return undefined;
-    const date = dataRef.current.latestDataDate;
+    const date = data.latestDataDate;
     return date ? DATA_AS_OF_FORMATTER.format(date) : undefined;
-  }, [isLoading]);
+  }, [isLoading, data]);
 
-  const content = isLoading ? null : (
+  const showNpmTab = !isLoading && !loadError ? data.hasNpmData : true;
+  const effectiveTab = showNpmTab ? activeTab : 'github';
+
+  const content = isLoading ? null : loadError ? (
+    <div className="app__error">
+      <h2>
+        {loadError === 'not-found'
+          ? `GitHub user "${liveUser}" was not found`
+          : 'Live data is currently unavailable — please try again later'}
+      </h2>
+      <p>
+        <a href="/">Back to metrics.tamino.dev</a>
+      </p>
+    </div>
+  ) : (
     <div className="app__content">
-      <Header activeTab={activeTab} onTabChange={setActiveTab} dataAsOf={dataAsOf} />
-      {activeTab === 'github' ? githubContent : npmContent}
+      <Header
+        activeTab={effectiveTab}
+        onTabChange={setActiveTab}
+        dataAsOf={dataAsOf}
+        showNpmTab={showNpmTab}
+        liveUser={liveUser}
+      />
+      {effectiveTab === 'github' ? githubContent : npmContent}
       <Footer />
     </div>
   );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -38,6 +38,7 @@ const DATA_AS_OF_FORMATTER = new Intl.DateTimeFormat('en-US', {
 
 interface AppProps {
   style?: React.CSSProperties;
+  liveUser?: string;
 }
 
 const syncViewport = () => {
@@ -57,7 +58,8 @@ const syncViewport = () => {
   return () => window.removeEventListener('resize', setViewport);
 };
 
-export default function App({ style }: AppProps) {
+export default function App({ style, liveUser }: AppProps) {
+  void liveUser;
   const dataRef = useRef(new Data());
   const [isLoading, setIsLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<MetricsTab>('github');

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -106,7 +106,7 @@ export default function App({ style, liveUser }: AppProps) {
           </Row>
           <Row
             type={RowType.LAST_THIRD}
-            first={<GithubWeekdayComparisonCard data={data} />}
+            first={<GithubWeekdayComparisonCard data={data} legendLabel="Contributions" />}
             last={<GithubFollowersCard data={data} />}
           />
           <Row>

--- a/src/components/Card/github/GithubContributionTotalsCard/GithubContributionTotalsCard.tsx
+++ b/src/components/Card/github/GithubContributionTotalsCard/GithubContributionTotalsCard.tsx
@@ -1,0 +1,34 @@
+import { type FC, memo } from 'react';
+import { Bar } from '@/components/shared/Bar';
+import { Card } from '@/components/shared/Card';
+import { CountTo } from '@/components/shared/CountTo';
+import { Legend } from '@/components/shared/Legend';
+import type { MetricsData } from '@/models/MetricsData';
+import type { DataPoint } from '@/types/ComponentStats';
+import '../GithubTotalCountsCard/GithubTotalCountsCard.css';
+
+interface GithubContributionTotalsCardProps {
+  data: MetricsData;
+}
+
+export const GithubContributionTotalsCard: FC<GithubContributionTotalsCardProps> = memo(({ data }) => {
+  const repos = Object.values(data.githubPublicRepositories);
+
+  const sections: DataPoint[] = [
+    { color: 'color-1', title: 'Repositories', value: repos.length },
+    { color: 'color-2', title: 'Stars', value: repos.reduce((sum, repo) => sum + repo.stargazerCount, 0) },
+    { color: 'color-3', title: 'Forks', value: repos.reduce((sum, repo) => sum + repo.forkCount, 0) },
+  ];
+
+  return (
+    <Card title="Total Counts" className="github-total-counts-card">
+      <h3>
+        <CountTo inline endVal={data.githubCommitStatTotals.commitCount} /> Contributions
+      </h3>
+      <h4>In Total</h4>
+      <hr />
+      <Legend className="github-total-counts-card__legend" sections={sections} />
+      <Bar sections={sections} />
+    </Card>
+  );
+});

--- a/src/components/Card/github/GithubDaytimeChartCard/GithubDaytimeChartCard.tsx
+++ b/src/components/Card/github/GithubDaytimeChartCard/GithubDaytimeChartCard.tsx
@@ -3,11 +3,11 @@ import { Chart } from '@/components/shared/Chart';
 import type { Graph } from '@/types/ComponentStats';
 import './GithubDaytimeChartCard.css';
 import { HOUR_TITLES, HOURS, WEEKDAY_TITLES_LONG, WEEKDAYS } from '@/constants';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import { joinHourKey } from '@/util/recordKey';
 
 interface GithubDaytimeChartCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 export const GithubDaytimeChartCard: FC<GithubDaytimeChartCardProps> = memo(({ data }) => {

--- a/src/components/Card/github/GithubFollowersCard/GithubFollowersCard.tsx
+++ b/src/components/Card/github/GithubFollowersCard/GithubFollowersCard.tsx
@@ -1,11 +1,11 @@
 import { type FC, memo } from 'react';
 import { PieChartComparisonCard } from '@/components/shared/PieChartComparisonCard';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import type { DataPoint } from '@/types/ComponentStats';
 import './GithubFollowersCard.css';
 
 interface GithubFollowersCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 export const GithubFollowersCard: FC<GithubFollowersCardProps> = memo(({ data }) => {

--- a/src/components/Card/github/GithubPopularReposCard/GithubPopularReposCard.tsx
+++ b/src/components/Card/github/GithubPopularReposCard/GithubPopularReposCard.tsx
@@ -3,12 +3,12 @@ import { Bar } from '@/components/shared/Bar';
 import { ButtonGroup } from '@/components/shared/ButtonGroup';
 import { Card } from '@/components/shared/Card';
 import { CountTo } from '@/components/shared/CountTo';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import type { PublicRepositoryDetails } from '@/types/GitHubStats';
 import './GithubPopularReposCard.css';
 
 interface GithubPopularReposCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MAX_DISPLAYED_REPOS = 6;

--- a/src/components/Card/github/GithubTimelineCard/GithubTimelineCard.tsx
+++ b/src/components/Card/github/GithubTimelineCard/GithubTimelineCard.tsx
@@ -1,7 +1,7 @@
 import { type FC, useState } from 'react';
 import { Chart, ChartType } from '@/components/shared/Chart';
 import { CHANGE_TYPE_TITLES, CHANGE_TYPES, VISIBILITIES, VISIBILITY_TITLES } from '@/constants';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import {
   changeTypeCommitKey,
   getMonthYearKeysForYear,
@@ -12,7 +12,7 @@ import './GithubTimelineCard.css';
 import { ButtonGroup } from '@/components/shared/ButtonGroup';
 
 interface GithubTimelineCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MODES = ['Change Type', 'Changed Files', 'Commits'] as const;

--- a/src/components/Card/github/GithubTotalCountsCard/GithubTotalCountsCard.tsx
+++ b/src/components/Card/github/GithubTotalCountsCard/GithubTotalCountsCard.tsx
@@ -5,10 +5,10 @@ import { Legend } from '@/components/shared/Legend';
 import type { DataPoint } from '@/types/ComponentStats';
 import './GithubTotalCountsCard.css';
 import { type FC, memo } from 'react';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 
 interface GithubTotalCountsCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 export const GithubTotalCountsCard: FC<GithubTotalCountsCardProps> = memo(({ data }) => {

--- a/src/components/Card/github/GithubUserCard/GithubUserCard.tsx
+++ b/src/components/Card/github/GithubUserCard/GithubUserCard.tsx
@@ -4,10 +4,10 @@ import { Legend } from '@/components/shared/Legend';
 import type { DataPoint } from '@/types/ComponentStats';
 import { GithubBio } from './GithubBio';
 import './GithubUserCard.css';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 
 interface GithubUserCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 export const GithubUserCard: FC<GithubUserCardProps> = memo(({ data }) => {

--- a/src/components/Card/github/GithubVisibilityComparisionCard/GithubVisibilityComparisionCard.tsx
+++ b/src/components/Card/github/GithubVisibilityComparisionCard/GithubVisibilityComparisionCard.tsx
@@ -1,13 +1,13 @@
 import { type FC, memo } from 'react';
 import { PieChartComparisonCard } from '@/components/shared/PieChartComparisonCard';
 import { VISIBILITIES, VISIBILITY_TITLES } from '@/constants';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import type { DataPoint } from '@/types/ComponentStats';
 import { visibilityCommitKey } from '@/util/recordKey';
 import './GithubVisibilityComparisionCard.css';
 
 interface GithubVisibilityComparisionCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 export const GithubVisibilityComparisionCard: FC<GithubVisibilityComparisionCardProps> = memo(({ data }) => {

--- a/src/components/Card/github/GithubWeekdayChartCard/GithubWeekdayChartCard.tsx
+++ b/src/components/Card/github/GithubWeekdayChartCard/GithubWeekdayChartCard.tsx
@@ -8,14 +8,14 @@ import {
   VISIBILITY_TITLES,
   WEEKDAY_TITLES_LONG,
 } from '@/constants';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import type { Graph } from '@/types/ComponentStats';
 import { changeTypeCommitKey, visibilityChangedFilesKey, visibilityCommitKey } from '@/util/recordKey';
 import './GithubWeekdayChartCard.css';
 import { ButtonGroup } from '@/components/shared/ButtonGroup';
 
 interface GithubWeekdayChartCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MODES = ['Change Type', 'Changed Files', 'Commits'] as const;

--- a/src/components/Card/github/GithubWeekdayComparisonCard/GithubWeekdayComparisonCard.tsx
+++ b/src/components/Card/github/GithubWeekdayComparisonCard/GithubWeekdayComparisonCard.tsx
@@ -3,13 +3,13 @@ import { Bar, BarType } from '@/components/shared/Bar';
 import { Card } from '@/components/shared/Card';
 import { Legend } from '@/components/shared/Legend';
 import { VISIBILITIES, VISIBILITY_TITLES, WEEKDAY_TITLES_SHORT, WEEKDAYS } from '@/constants';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import type { DataPoint } from '@/types/ComponentStats';
 import { visibilityCommitKey } from '@/util/recordKey';
 import './GithubWeekdayComparisonCard.css';
 
 interface GithubWeekdayComparisonCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 export const GithubWeekdayComparisonCard: FC<GithubWeekdayComparisonCardProps> = memo(({ data }) => {

--- a/src/components/Card/github/GithubWeekdayComparisonCard/GithubWeekdayComparisonCard.tsx
+++ b/src/components/Card/github/GithubWeekdayComparisonCard/GithubWeekdayComparisonCard.tsx
@@ -10,9 +10,10 @@ import './GithubWeekdayComparisonCard.css';
 
 interface GithubWeekdayComparisonCardProps {
   data: MetricsData;
+  legendLabel?: string;
 }
 
-export const GithubWeekdayComparisonCard: FC<GithubWeekdayComparisonCardProps> = memo(({ data }) => {
+export const GithubWeekdayComparisonCard: FC<GithubWeekdayComparisonCardProps> = memo(({ data, legendLabel }) => {
   const { githubCommitStatsPerWeekday: commitStatsPerWeekday } = data;
   const maxSum = Math.max(...Object.values(commitStatsPerWeekday).map((counts) => counts.commitCount));
 
@@ -33,11 +34,13 @@ export const GithubWeekdayComparisonCard: FC<GithubWeekdayComparisonCardProps> =
 
   const xAxisLabels = WEEKDAY_TITLES_SHORT.map((label, i) => <span key={i}>{label}</span>);
 
-  const sections: DataPoint[] = VISIBILITIES.map((visibility, i) => ({
-    color: `color-${visibility}`,
-    title: VISIBILITY_TITLES[i],
-    value: 0,
-  }));
+  const sections: DataPoint[] = legendLabel
+    ? [{ color: 'color-public', title: legendLabel, value: 0 }]
+    : VISIBILITIES.map((visibility, i) => ({
+        color: `color-${visibility}`,
+        title: VISIBILITY_TITLES[i],
+        value: 0,
+      }));
 
   return (
     <Card

--- a/src/components/Card/github/GithubYearChartCard/GithubYearChartCard.tsx
+++ b/src/components/Card/github/GithubYearChartCard/GithubYearChartCard.tsx
@@ -1,7 +1,7 @@
 import { type FC, memo } from 'react';
 import { Chart } from '@/components/shared/Chart';
 import { MONTH_TITLES_SHORT, MONTHS } from '@/constants';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import type { Graph, MonthYearKey } from '@/types/ComponentStats';
 import { getMonthYearKeysForYear } from '@/util/recordKey';
 import './GithubYearChartCard.css';
@@ -9,7 +9,7 @@ import './GithubYearChartCard.css';
 const MAX_DISPLAYED_YEARS = 7;
 
 interface GithubYearChartCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 export const GithubYearChartCard: FC<GithubYearChartCardProps> = memo(({ data }) => {

--- a/src/components/Card/github/GithubYearHeatmapCard/GithubYearHeatmapCard.tsx
+++ b/src/components/Card/github/GithubYearHeatmapCard/GithubYearHeatmapCard.tsx
@@ -12,11 +12,12 @@ import { getDateKeysForYear } from '@/util/recordKey';
 
 interface GithubYearHeatmapCardProps {
   data: MetricsData;
+  countLabel?: string;
 }
 
 const MAX_DISPLAYED_REPOS = 6;
 
-export const GithubYearHeatmapCard: FC<GithubYearHeatmapCardProps> = ({ data }) => {
+export const GithubYearHeatmapCard: FC<GithubYearHeatmapCardProps> = ({ data, countLabel = 'Commits' }) => {
   const {
     githubCommitsPerDate: commitsPerDate,
     githubCommitsPerYearAndRepository: commitsPerYearAndRepository,
@@ -65,7 +66,7 @@ export const GithubYearHeatmapCard: FC<GithubYearHeatmapCardProps> = ({ data }) 
     >
       <h3>Year {year}</h3>
       <h4>
-        <CountTo duration={500} inline endVal={commitsPerYear[year]?.commitCount ?? 0} /> Commits
+        <CountTo duration={500} inline endVal={commitsPerYear[year]?.commitCount ?? 0} /> {countLabel}
       </h4>
       <hr />
       <h3 className="github-year-heatmap-card__highlights">Highlights</h3>

--- a/src/components/Card/github/GithubYearHeatmapCard/GithubYearHeatmapCard.tsx
+++ b/src/components/Card/github/GithubYearHeatmapCard/GithubYearHeatmapCard.tsx
@@ -7,11 +7,11 @@ import { Heatmap } from '@/components/shared/Heatmap';
 import { Legend } from '@/components/shared/Legend';
 import type { DataPoint } from '@/types/ComponentStats';
 import './GithubYearHeatmapCard.css';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import { getDateKeysForYear } from '@/util/recordKey';
 
 interface GithubYearHeatmapCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MAX_DISPLAYED_REPOS = 6;

--- a/src/components/Card/npm/NpmDownloadHeatmapCard/NpmDownloadHeatmapCard.tsx
+++ b/src/components/Card/npm/NpmDownloadHeatmapCard/NpmDownloadHeatmapCard.tsx
@@ -4,11 +4,11 @@ import { Card } from '@/components/shared/Card';
 import { CountTo } from '@/components/shared/CountTo';
 import { Heatmap } from '@/components/shared/Heatmap';
 import './NpmDownloadHeatmapCard.css';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import { getDateKeysForYear } from '@/util/recordKey';
 
 interface NpmDownloadHeatmapCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 export const NpmDownloadHeatmapCard: FC<NpmDownloadHeatmapCardProps> = ({ data }) => {

--- a/src/components/Card/npm/NpmDownloadTimelineCard/NpmDownloadTimelineCard.tsx
+++ b/src/components/Card/npm/NpmDownloadTimelineCard/NpmDownloadTimelineCard.tsx
@@ -1,11 +1,11 @@
 import type { FC } from 'react';
 import { Chart, ChartType } from '@/components/shared/Chart';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import { getMonthYearKeysForYear } from '@/util/recordKey';
 import './NpmDownloadTimelineCard.css';
 
 interface NpmDownloadTimelineCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MAX_PACKAGES = 7;

--- a/src/components/Card/npm/NpmDownloadYearCard/NpmDownloadYearCard.tsx
+++ b/src/components/Card/npm/NpmDownloadYearCard/NpmDownloadYearCard.tsx
@@ -1,7 +1,7 @@
 import { type FC, memo } from 'react';
 import { Chart } from '@/components/shared/Chart';
 import { MONTH_TITLES_SHORT, MONTHS } from '@/constants';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import type { Graph, MonthYearKey } from '@/types/ComponentStats';
 import { getMonthYearKeysForYear } from '@/util/recordKey';
 import './NpmDownloadYearCard.css';
@@ -9,7 +9,7 @@ import './NpmDownloadYearCard.css';
 const MAX_DISPLAYED_YEARS = 7;
 
 interface NpmDownloadYearCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 export const NpmDownloadYearCard: FC<NpmDownloadYearCardProps> = memo(({ data }) => {

--- a/src/components/Card/npm/NpmOrgDetailCard/NpmOrgDetailCard.tsx
+++ b/src/components/Card/npm/NpmOrgDetailCard/NpmOrgDetailCard.tsx
@@ -5,12 +5,12 @@ import { Card } from '@/components/shared/Card';
 import { CountTo } from '@/components/shared/CountTo';
 import { Dropdown } from '@/components/shared/Dropdown';
 import { Legend } from '@/components/shared/Legend';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import type { DataPoint } from '@/types/ComponentStats';
 import './NpmOrgDetailCard.css';
 
 interface NpmOrgDetailCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MAX_DISPLAYED_PACKAGES = 5;

--- a/src/components/Card/npm/NpmOrgPackageTimelineCard/NpmOrgPackageTimelineCard.tsx
+++ b/src/components/Card/npm/NpmOrgPackageTimelineCard/NpmOrgPackageTimelineCard.tsx
@@ -2,14 +2,14 @@ import { type FC, useMemo, useState } from 'react';
 import { ButtonGroup } from '@/components/shared/ButtonGroup';
 import { Chart, ChartType } from '@/components/shared/Chart';
 import { Dropdown } from '@/components/shared/Dropdown';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import type { MonthYearKey } from '@/types/ComponentStats';
 import type { DateKey } from '@/types/GitHubStats';
 import { getMonthYearKeysForYear } from '@/util/recordKey';
 import './NpmOrgPackageTimelineCard.css';
 
 interface NpmOrgPackageTimelineCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MAX_PACKAGES = 8;

--- a/src/components/Card/npm/NpmOrgTimelineCard/NpmOrgTimelineCard.tsx
+++ b/src/components/Card/npm/NpmOrgTimelineCard/NpmOrgTimelineCard.tsx
@@ -1,13 +1,13 @@
 import { type FC, useState } from 'react';
 import { ButtonGroup } from '@/components/shared/ButtonGroup';
 import { Chart, ChartType } from '@/components/shared/Chart';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import type { MonthYearKey } from '@/types/ComponentStats';
 import { getMonthYearKeysForYear } from '@/util/recordKey';
 import './NpmOrgTimelineCard.css';
 
 interface NpmOrgTimelineCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MAX_ORGS = 5;

--- a/src/components/Card/npm/NpmOrganizationsCard/NpmOrganizationsCard.tsx
+++ b/src/components/Card/npm/NpmOrganizationsCard/NpmOrganizationsCard.tsx
@@ -3,11 +3,11 @@ import { Bar } from '@/components/shared/Bar';
 import { ButtonGroup } from '@/components/shared/ButtonGroup';
 import { Card } from '@/components/shared/Card';
 import { CountTo } from '@/components/shared/CountTo';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import './NpmOrganizationsCard.css';
 
 interface NpmOrganizationsCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MAX_DISPLAYED_ORGS = 6;

--- a/src/components/Card/npm/NpmPopularPackagesCard/NpmPopularPackagesCard.tsx
+++ b/src/components/Card/npm/NpmPopularPackagesCard/NpmPopularPackagesCard.tsx
@@ -3,11 +3,11 @@ import { Bar } from '@/components/shared/Bar';
 import { ButtonGroup } from '@/components/shared/ButtonGroup';
 import { Card } from '@/components/shared/Card';
 import { CountTo } from '@/components/shared/CountTo';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import './NpmPopularPackagesCard.css';
 
 interface NpmPopularPackagesCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MAX_DISPLAYED_PACKAGES = 8;

--- a/src/components/Card/npm/NpmPublishDaytimeCard/NpmPublishDaytimeCard.tsx
+++ b/src/components/Card/npm/NpmPublishDaytimeCard/NpmPublishDaytimeCard.tsx
@@ -3,11 +3,11 @@ import { Chart } from '@/components/shared/Chart';
 import type { Graph } from '@/types/ComponentStats';
 import './NpmPublishDaytimeCard.css';
 import { HOUR_TITLES, HOURS, WEEKDAY_TITLES_LONG, WEEKDAYS } from '@/constants';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import { joinHourKey } from '@/util/recordKey';
 
 interface NpmPublishDaytimeCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 export const NpmPublishDaytimeCard: FC<NpmPublishDaytimeCardProps> = memo(({ data }) => {

--- a/src/components/Card/npm/NpmTotalCountsCard/NpmTotalCountsCard.tsx
+++ b/src/components/Card/npm/NpmTotalCountsCard/NpmTotalCountsCard.tsx
@@ -5,10 +5,10 @@ import { Legend } from '@/components/shared/Legend';
 import type { DataPoint } from '@/types/ComponentStats';
 import './NpmTotalCountsCard.css';
 import { type FC, memo } from 'react';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 
 interface NpmTotalCountsCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 export const NpmTotalCountsCard: FC<NpmTotalCountsCardProps> = memo(({ data }) => {

--- a/src/components/Card/npm/NpmUserCard/NpmUserCard.tsx
+++ b/src/components/Card/npm/NpmUserCard/NpmUserCard.tsx
@@ -3,10 +3,10 @@ import { Card } from '@/components/shared/Card';
 import { Legend } from '@/components/shared/Legend';
 import type { DataPoint } from '@/types/ComponentStats';
 import './NpmUserCard.css';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 
 interface NpmUserCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MAX_DISPLAYED_ORGANIZATIONS = 4;

--- a/src/components/Card/npm/NpmVersionHeatmapCard/NpmVersionHeatmapCard.tsx
+++ b/src/components/Card/npm/NpmVersionHeatmapCard/NpmVersionHeatmapCard.tsx
@@ -7,11 +7,11 @@ import { Heatmap } from '@/components/shared/Heatmap';
 import { Legend } from '@/components/shared/Legend';
 import type { DataPoint } from '@/types/ComponentStats';
 import './NpmVersionHeatmapCard.css';
-import type Data from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
 import { getDateKeysForYear } from '@/util/recordKey';
 
 interface NpmVersionHeatmapCardProps {
-  data: Data;
+  data: MetricsData;
 }
 
 const MAX_DISPLAYED_ORGS = 6;

--- a/src/components/Layout/Header.css
+++ b/src/components/Layout/Header.css
@@ -15,6 +15,18 @@
   margin: 0;
 }
 
+.header__title {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.header__live-user {
+  font-size: 1.1rem;
+  opacity: 0.7;
+  align-self: center;
+}
+
 .header__right {
   display: flex;
   align-items: center;

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -7,15 +7,18 @@ interface HeaderProps {
   activeTab: MetricsTab;
   onTabChange: (tab: MetricsTab) => void;
   dataAsOf?: string;
+  showNpmTab?: boolean;
+  liveUser?: string;
 }
 
-export const Header: FC<HeaderProps> = memo(({ activeTab, onTabChange, dataAsOf }) => {
+export const Header: FC<HeaderProps> = memo(({ activeTab, onTabChange, dataAsOf, showNpmTab = true, liveUser }) => {
   const tabsRef = useRef<HTMLElement>(null);
   const githubRef = useRef<HTMLButtonElement>(null);
   const npmRef = useRef<HTMLButtonElement>(null);
   const [barStyle, setBarStyle] = useState<React.CSSProperties>({});
 
   useEffect(() => {
+    if (activeTab === 'npm' && !showNpmTab) return;
     const activeRef = activeTab === 'github' ? githubRef : npmRef;
     const btn = activeRef.current;
     const nav = tabsRef.current;
@@ -28,12 +31,15 @@ export const Header: FC<HeaderProps> = memo(({ activeTab, onTabChange, dataAsOf 
       width: `${btnRect.width}px`,
       transform: `translateX(${btnRect.left - navRect.left}px)`,
     });
-  }, [activeTab]);
+  }, [activeTab, showNpmTab]);
 
   return (
     <header className="header">
       <div className="header__content">
-        <h1>Metrics</h1>
+        <div className="header__title">
+          <h1>Metrics</h1>
+          {liveUser ? <span className="header__live-user">~{liveUser}</span> : null}
+        </div>
         <div className="header__right">
           {dataAsOf ? <span className="header__updated">Updated {dataAsOf}</span> : null}
           <nav className="header__tabs" ref={tabsRef}>
@@ -45,14 +51,16 @@ export const Header: FC<HeaderProps> = memo(({ activeTab, onTabChange, dataAsOf 
             >
               GitHub
             </button>
-            <button
-              type="button"
-              ref={npmRef}
-              className={`header__tab${activeTab === 'npm' ? ' header__tab--active' : ''}`}
-              onClick={() => onTabChange('npm')}
-            >
-              npm
-            </button>
+            {showNpmTab ? (
+              <button
+                type="button"
+                ref={npmRef}
+                className={`header__tab${activeTab === 'npm' ? ' header__tab--active' : ''}`}
+                onClick={() => onTabChange('npm')}
+              >
+                npm
+              </button>
+            ) : null}
             <div className="header__bar" style={barStyle} />
           </nav>
         </div>

--- a/src/live/metricsApi.test.ts
+++ b/src/live/metricsApi.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { MetricsApiClient, MetricsApiError } from '@/live/metricsApi';
+
+const recordingFetch = (status = 200, body: unknown = {}): { calls: string[]; fetch: typeof fetch } => {
+  const calls: string[] = [];
+  const fetchFn = (async (input: RequestInfo | URL) => {
+    calls.push(String(input));
+    return new Response(JSON.stringify(body), { status });
+  }) as typeof fetch;
+  return { calls, fetch: fetchFn };
+};
+
+describe('MetricsApiClient', () => {
+  it('builds endpoint URLs against the default base', async () => {
+    const { calls, fetch } = recordingFetch();
+    const client = new MetricsApiClient({ fetch });
+    await client.githubContributions('octocat');
+    await client.githubProfile('octocat');
+    await client.githubRepos('octocat');
+    await client.npmStats('octocat');
+    expect(calls).toEqual([
+      'https://metrics-api.tamino.dev/github/octocat/contributions',
+      'https://metrics-api.tamino.dev/github/octocat/profile',
+      'https://metrics-api.tamino.dev/github/octocat/repos',
+      'https://metrics-api.tamino.dev/npm/octocat',
+    ]);
+  });
+
+  it('maps 404 to MetricsApiError kind not-found', async () => {
+    const { fetch } = recordingFetch(404, { error: 'user not found: x' });
+    const error = await new MetricsApiClient({ fetch }).githubProfile('x').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(MetricsApiError);
+    expect((error as MetricsApiError).kind).toBe('not-found');
+  });
+});

--- a/src/live/metricsApi.test.ts
+++ b/src/live/metricsApi.test.ts
@@ -14,21 +14,33 @@ describe('MetricsApiClient', () => {
   it('builds endpoint URLs against the default base', async () => {
     const { calls, fetch } = recordingFetch();
     const client = new MetricsApiClient({ fetch });
-    await client.githubContributions('octocat');
-    await client.githubProfile('octocat');
-    await client.githubRepos('octocat');
+    await client.github('octocat');
+    await client.github('octocat', { years: [2016, 2017] });
+    await client.github('octocat', { years: 'last', lifetime: true });
     await client.npmStats('octocat');
+    await client.npmStats('octocat', { months: 6 });
     expect(calls).toEqual([
-      'https://metrics-api.tamino.dev/github/octocat/contributions',
-      'https://metrics-api.tamino.dev/github/octocat/profile',
-      'https://metrics-api.tamino.dev/github/octocat/repos',
+      'https://metrics-api.tamino.dev/github/octocat',
+      'https://metrics-api.tamino.dev/github/octocat?y=2016%2C2017',
+      'https://metrics-api.tamino.dev/github/octocat?y=last&lifetime=1',
       'https://metrics-api.tamino.dev/npm/octocat',
+      'https://metrics-api.tamino.dev/npm/octocat?months=6',
     ]);
+  });
+
+  it('sends a Bearer token when provided', async () => {
+    let sentAuth: string | null = null;
+    const fetchFn = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      sentAuth = new Headers(init?.headers).get('authorization');
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+    await new MetricsApiClient({ fetch: fetchFn }).github('octocat', { token: 'secret' });
+    expect(sentAuth).toBe('Bearer secret');
   });
 
   it('maps 404 to MetricsApiError kind not-found', async () => {
     const { fetch } = recordingFetch(404, { error: 'user not found: x' });
-    const error = await new MetricsApiClient({ fetch }).githubProfile('x').catch((e: unknown) => e);
+    const error = await new MetricsApiClient({ fetch }).github('x').catch((e: unknown) => e);
     expect(error).toBeInstanceOf(MetricsApiError);
     expect((error as MetricsApiError).kind).toBe('not-found');
   });

--- a/src/live/metricsApi.ts
+++ b/src/live/metricsApi.ts
@@ -1,4 +1,4 @@
-// Vendored from node-metrics-api packages/metrics-api-client — replace with the npm package once it is public.
+// Vendored from node-metrics-api packages/metrics-api-client (tracks v0.0.3) — replace with the npm package once it is public.
 
 import type { AccountStats as NpmAccountStats } from '@/types/NpmStats';
 
@@ -12,9 +12,19 @@ export interface ContributionDay {
   level: ContributionLevel;
 }
 
+export interface GithubByType {
+  commits: number;
+  pullRequests: number;
+  reviews: number;
+  issues: number;
+}
+
 export interface GithubContributions {
   total: Record<string, number>;
   contributions: ContributionDay[];
+  byType?: GithubByType;
+  privateLastYear?: number;
+  lifetimeTotal?: number;
 }
 
 export interface GithubOrganization {
@@ -32,6 +42,8 @@ export interface GithubProfile {
   followerCount: number;
   followingCount: number;
   organizations: GithubOrganization[];
+  accountCreatedAt?: string;
+  location?: string | null;
 }
 
 export interface GithubRepo {
@@ -42,6 +54,17 @@ export interface GithubRepo {
   stargazerCount: number;
   forkCount: number;
   isFork: boolean;
+  defaultBranchCommits?: number | null;
+  createdAt?: string;
+  pushedAt?: string;
+}
+
+/** Combined GitHub payload returned by `GET /github/:user` (metrics-api-server >= 0.0.3). */
+export interface GithubUser {
+  profile: GithubProfile;
+  repos: GithubRepo[];
+  contributions: GithubContributions;
+  warnings?: string[];
 }
 
 export type MetricsApiErrorKind = 'bad-request' | 'not-found' | 'upstream' | 'network';
@@ -72,11 +95,13 @@ export class MetricsApiClient {
     this.#fetch = options.fetch ?? globalThis.fetch.bind(globalThis);
   }
 
-  async #get<T>(path: string): Promise<T> {
-    const url = `${this.#baseUrl}${path}`;
+  async #get<T>(path: string, params: Record<string, string> = {}, token?: string): Promise<T> {
+    const query = new URLSearchParams(params).toString();
+    const url = `${this.#baseUrl}${path}${query ? `?${query}` : ''}`;
+    const init = token ? { headers: { authorization: `Bearer ${token}` } } : undefined;
     let response: Response;
     try {
-      response = await this.#fetch(url);
+      response = await this.#fetch(url, init);
     } catch (error) {
       throw new MetricsApiError('network', 0, `request failed: ${String(error)}`);
     }
@@ -89,19 +114,21 @@ export class MetricsApiClient {
     return response.json() as Promise<T>;
   }
 
-  githubContributions(user: string): Promise<GithubContributions> {
-    return this.#get(`/github/${encodeURIComponent(user)}/contributions`);
+  github(
+    user: string,
+    options: { years?: 'all' | 'last' | number[]; token?: string; lifetime?: boolean } = {},
+  ): Promise<GithubUser> {
+    const params: Record<string, string> = {};
+    if (options.years && options.years !== 'all') {
+      params.y = Array.isArray(options.years) ? options.years.join(',') : options.years;
+    }
+    if (options.lifetime) params.lifetime = '1';
+    return this.#get(`/github/${encodeURIComponent(user)}`, params, options.token);
   }
 
-  githubProfile(user: string): Promise<GithubProfile> {
-    return this.#get(`/github/${encodeURIComponent(user)}/profile`);
-  }
-
-  githubRepos(user: string): Promise<GithubRepo[]> {
-    return this.#get(`/github/${encodeURIComponent(user)}/repos`);
-  }
-
-  npmStats(user: string): Promise<NpmAccountStats> {
-    return this.#get(`/npm/${encodeURIComponent(user)}`);
+  npmStats(user: string, options: { months?: number } = {}): Promise<NpmAccountStats> {
+    const params: Record<string, string> = {};
+    if (options.months !== undefined) params.months = String(options.months);
+    return this.#get(`/npm/${encodeURIComponent(user)}`, params);
   }
 }

--- a/src/live/metricsApi.ts
+++ b/src/live/metricsApi.ts
@@ -1,0 +1,107 @@
+// Vendored from node-metrics-api packages/metrics-api-client — replace with the npm package once it is public.
+
+import type { AccountStats as NpmAccountStats } from '@/types/NpmStats';
+
+export const DEFAULT_BASE_URL = 'https://metrics-api.tamino.dev';
+
+export type ContributionLevel = 0 | 1 | 2 | 3 | 4;
+
+export interface ContributionDay {
+  date: string;
+  count: number;
+  level: ContributionLevel;
+}
+
+export interface GithubContributions {
+  total: Record<string, number>;
+  contributions: ContributionDay[];
+}
+
+export interface GithubOrganization {
+  name: string;
+  avatarUrl: string;
+  url: string;
+}
+
+export interface GithubProfile {
+  name: string;
+  username: string;
+  bio: string;
+  avatarUrl: string;
+  url: string;
+  followerCount: number;
+  followingCount: number;
+  organizations: GithubOrganization[];
+}
+
+export interface GithubRepo {
+  name: string;
+  url: string;
+  description: string;
+  language: string | null;
+  stargazerCount: number;
+  forkCount: number;
+  isFork: boolean;
+}
+
+export type MetricsApiErrorKind = 'bad-request' | 'not-found' | 'upstream' | 'network';
+
+export class MetricsApiError extends Error {
+  constructor(
+    readonly kind: MetricsApiErrorKind,
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'MetricsApiError';
+  }
+}
+
+export interface MetricsApiClientOptions {
+  baseUrl?: string;
+  fetch?: typeof fetch;
+}
+
+export class MetricsApiClient {
+  readonly #baseUrl: string;
+  readonly #fetch: typeof fetch;
+
+  constructor(options: MetricsApiClientOptions = {}) {
+    const envBase = import.meta.env?.VITE_METRICS_API_URL as string | undefined;
+    this.#baseUrl = (options.baseUrl ?? envBase ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+    this.#fetch = options.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  async #get<T>(path: string): Promise<T> {
+    const url = `${this.#baseUrl}${path}`;
+    let response: Response;
+    try {
+      response = await this.#fetch(url);
+    } catch (error) {
+      throw new MetricsApiError('network', 0, `request failed: ${String(error)}`);
+    }
+    if (!response.ok) {
+      const kind: MetricsApiErrorKind =
+        response.status === 404 ? 'not-found' : response.status === 400 ? 'bad-request' : 'upstream';
+      const body = (await response.json().catch(() => ({}))) as { error?: string };
+      throw new MetricsApiError(kind, response.status, body.error ?? `request failed with ${response.status}`);
+    }
+    return response.json() as Promise<T>;
+  }
+
+  githubContributions(user: string): Promise<GithubContributions> {
+    return this.#get(`/github/${encodeURIComponent(user)}/contributions`);
+  }
+
+  githubProfile(user: string): Promise<GithubProfile> {
+    return this.#get(`/github/${encodeURIComponent(user)}/profile`);
+  }
+
+  githubRepos(user: string): Promise<GithubRepo[]> {
+    return this.#get(`/github/${encodeURIComponent(user)}/repos`);
+  }
+
+  npmStats(user: string): Promise<NpmAccountStats> {
+    return this.#get(`/npm/${encodeURIComponent(user)}`);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,11 @@
 import { createRoot } from 'react-dom/client';
 import App from '@/components/App';
+import { parseLiveUser } from '@/util/route';
+
+const liveUser = parseLiveUser(window.location.pathname) ?? undefined;
 
 function Main() {
-  return <App />;
+  return <App liveUser={liveUser} />;
 }
 
 createRoot(document.getElementById('app')!).render(<Main />);

--- a/src/models/Data.ts
+++ b/src/models/Data.ts
@@ -1,3 +1,4 @@
+import type { MetricsData } from '@/models/MetricsData';
 import type {
   MonthYearKey,
   NpmOrganizationStats,
@@ -38,7 +39,7 @@ export const EMPTY_COMMIT_STATS: Readonly<PrivatePublicCommitStats> = Object.fre
   privateChangedFiles: 0,
 });
 
-export class Data {
+export class Data implements MetricsData {
   // GitHub data
   #githubAccountStats: AccountStats | null = null;
   #githubCommitsPerLanguage: Record<string, number> = {};
@@ -528,6 +529,10 @@ export class Data {
         }, MIN_WAIT_DURATION - duration);
       });
     }
+  }
+
+  get hasNpmData(): boolean {
+    return true;
   }
 
   // GitHub getters

--- a/src/models/Data.ts
+++ b/src/models/Data.ts
@@ -13,10 +13,11 @@ import type {
 } from '@/types/GitHubStats';
 import type { AccountStats as NpmAccountStats, PackageStats } from '@/types/NpmStats';
 import { splitDateKey, splitHourKey } from '@/util/recordKey';
+import { waitRemainder } from '@/util/timing';
 
 const GITHUB_ACCOUNTS = ['tamino-martinius', 'tamino-cookieai'];
 const NPM_ACCOUNT = 'tamino-martinius';
-const MIN_WAIT_DURATION = 1_650;
+export const MIN_WAIT_DURATION = 1_650;
 
 const accountUrls = GITHUB_ACCOUNTS.map(
   (account) => `https://raw.githubusercontent.com/${account}/github-stats/${account}/data/stats.json`,
@@ -241,14 +242,7 @@ export class Data implements MetricsData {
     this.#npmAccountStats = npmAccountStats;
     this.#calculateGithubAccountStats();
     this.#npm = aggregateNpmStats(npmAccountStats);
-    const duration = Date.now() - startTime;
-    if (duration < MIN_WAIT_DURATION) {
-      await new Promise((resolve) => {
-        setTimeout(() => {
-          resolve(true);
-        }, MIN_WAIT_DURATION - duration);
-      });
-    }
+    await waitRemainder(startTime, MIN_WAIT_DURATION);
   }
 
   get hasNpmData(): boolean {

--- a/src/models/Data.ts
+++ b/src/models/Data.ts
@@ -1,10 +1,6 @@
 import type { MetricsData } from '@/models/MetricsData';
-import type {
-  MonthYearKey,
-  NpmOrganizationStats,
-  NpmPackageStats,
-  PrivatePublicCommitStats,
-} from '@/types/ComponentStats';
+import { aggregateNpmStats, emptyNpmAggregates, type NpmAggregates } from '@/models/npmAggregates';
+import type { MonthYearKey, PrivatePublicCommitStats } from '@/types/ComponentStats';
 import type {
   AccountStats,
   DateKey,
@@ -15,7 +11,7 @@ import type {
   Weekday,
   Year,
 } from '@/types/GitHubStats';
-import type { AccountStats as NpmAccountStats, PackageDetails, PackageStats } from '@/types/NpmStats';
+import type { AccountStats as NpmAccountStats, PackageStats } from '@/types/NpmStats';
 import { splitDateKey, splitHourKey } from '@/util/recordKey';
 
 const GITHUB_ACCOUNTS = ['tamino-martinius', 'tamino-cookieai'];
@@ -58,26 +54,7 @@ export class Data implements MetricsData {
 
   // NPM data
   #npmAccountStats: NpmAccountStats | null = null;
-  #npmTotalDownloads = 0;
-  #npmTotalVersions = 0;
-  #npmDownloadsPerDate: Partial<Record<DateKey, number>> = {};
-  #npmDownloadsPerYear: Partial<Record<Year, number>> = {};
-  #npmDownloadsPerMonthAndYear: Partial<Record<MonthYearKey, number>> = {};
-  #npmVersionsPerDate: Partial<Record<DateKey, number>> = {};
-  #npmVersionsPerHour: Partial<Record<HourKey, number>> = {};
-  #npmVersionsPerWeekday: Partial<Record<Weekday, number>> = {};
-  #npmPackageStats: Record<string, NpmPackageStats> = {};
-  #npmPackageStatsPerYear: Partial<Record<Year, Record<string, NpmPackageStats>>> = {};
-  #npmPackageStatsPerMonthAndYear: Partial<Record<MonthYearKey, Record<string, NpmPackageStats>>> = {};
-  #npmOrganizationStats: Record<string, NpmOrganizationStats> = {};
-  #npmOrganizationStatsPerYear: Partial<Record<Year, Record<string, NpmOrganizationStats>>> = {};
-  #npmOrganizationStatsPerMonthAndYear: Partial<Record<MonthYearKey, Record<string, NpmOrganizationStats>>> = {};
-  #npmOrganizationPackages: Record<string, string[]> = {};
-  #npmPackageWeeklyDownloads: Record<string, number> = {};
-  #npmPackageDownloadsPerWeek: Record<string, Record<string, number>> = {}; // weekKey -> { pkgName -> downloads }
-  #npmWeekKeys: DateKey[] = [];
-  #npmPackageDetails: Record<string, PackageDetails> = {};
-  #npmYears: Year[] = [];
+  #npm: NpmAggregates = emptyNpmAggregates();
 
   async #fetchGithubStats() {
     const responses = await Promise.all(accountUrls.map((url) => fetch(url)));
@@ -257,270 +234,13 @@ export class Data implements MetricsData {
     this.#githubYears = Array.from({ length: new Date().getFullYear() - minYear + 1 }).map((_x, i) => minYear + i);
   }
 
-  #calculateNpmAccountStats() {
-    if (!this.#npmAccountStats) return;
-
-    // Compute last full week (Mon-Sun) date keys
-    const today = new Date();
-    const dayOfWeek = today.getDay(); // 0=Sun, 1=Mon, ...
-    const lastSunday = new Date(today);
-    lastSunday.setDate(today.getDate() - (dayOfWeek === 0 ? 7 : dayOfWeek));
-    const lastMonday = new Date(lastSunday);
-    lastMonday.setDate(lastSunday.getDate() - 6);
-    const lastFullWeekDateKeys: DateKey[] = [];
-    for (const d = new Date(lastMonday); d <= lastSunday; d.setDate(d.getDate() + 1)) {
-      const y = d.getFullYear();
-      const m = String(d.getMonth() + 1).padStart(2, '0');
-      const day = String(d.getDate()).padStart(2, '0');
-      lastFullWeekDateKeys.push(`${y}-${m}-${day}` as DateKey);
-    }
-
-    // Aggregate user-level versions (for daytime/heatmap charts)
-    for (const [key, count] of Object.entries(this.#npmAccountStats.user.versionsPerDate)) {
-      if (!count) continue;
-      const dateKey = key as DateKey;
-      const [year] = splitDateKey(dateKey);
-
-      this.#npmVersionsPerDate[dateKey] = (this.#npmVersionsPerDate[dateKey] ?? 0) + count;
-
-      // Year
-      this.#npmDownloadsPerYear[year] = this.#npmDownloadsPerYear[year] ?? 0;
-    }
-
-    for (const [key, count] of Object.entries(this.#npmAccountStats.user.versionsPerHour)) {
-      if (!count) continue;
-      const hourKey = key as HourKey;
-      const [weekday] = splitHourKey(hourKey);
-
-      this.#npmVersionsPerHour[hourKey] = (this.#npmVersionsPerHour[hourKey] ?? 0) + count;
-      this.#npmVersionsPerWeekday[weekday] = (this.#npmVersionsPerWeekday[weekday] ?? 0) + count;
-    }
-
-    // Aggregate per-package data
-    for (const pkg of this.#npmAccountStats.packages) {
-      this.#npmPackageDetails[pkg.details.name] = pkg.details;
-      const organizationName = pkg.details.name.includes('/')
-        ? pkg.details.name.split('/')[0]
-        : this.#npmAccountStats.user.username;
-      if (!this.#npmOrganizationStats[organizationName]) {
-        this.#npmOrganizationStats[organizationName] = {
-          downloads: 0,
-          versions: 0,
-          packages: 0,
-        };
-      }
-      this.#npmOrganizationStats[organizationName].packages += 1;
-      if (!this.#npmOrganizationPackages[organizationName]) {
-        this.#npmOrganizationPackages[organizationName] = [];
-      }
-      this.#npmOrganizationPackages[organizationName].push(pkg.details.name);
-
-      let pkgDownloads = 0;
-      for (const [key, count] of Object.entries(pkg.downloadsPerDate)) {
-        if (!count) continue;
-        const dateKey = key as DateKey;
-        const [year, month] = splitDateKey(dateKey);
-        const monthYearKey = `${year}-${month}` satisfies MonthYearKey;
-
-        pkgDownloads += count;
-        this.#npmDownloadsPerDate[dateKey] = (this.#npmDownloadsPerDate[dateKey] ?? 0) + count;
-        this.#npmDownloadsPerYear[year] = (this.#npmDownloadsPerYear[year] ?? 0) + count;
-        this.#npmDownloadsPerMonthAndYear[monthYearKey] =
-          (this.#npmDownloadsPerMonthAndYear[monthYearKey] ?? 0) + count;
-
-        // Per-package per-year downloads
-        if (!this.#npmPackageStatsPerYear[year]) {
-          this.#npmPackageStatsPerYear[year] = {};
-        }
-        if (!this.#npmPackageStatsPerYear[year][pkg.details.name]) {
-          this.#npmPackageStatsPerYear[year][pkg.details.name] = { downloads: 0, versions: 0 };
-        }
-        this.#npmPackageStatsPerYear[year][pkg.details.name].downloads += count;
-
-        // Per-package per-month-year downloads
-        if (!this.#npmPackageStatsPerMonthAndYear[monthYearKey]) {
-          this.#npmPackageStatsPerMonthAndYear[monthYearKey] = {};
-        }
-        if (!this.#npmPackageStatsPerMonthAndYear[monthYearKey][pkg.details.name]) {
-          this.#npmPackageStatsPerMonthAndYear[monthYearKey][pkg.details.name] = { downloads: 0, versions: 0 };
-        }
-        this.#npmPackageStatsPerMonthAndYear[monthYearKey][pkg.details.name].downloads += count;
-
-        // Per-package per-week downloads
-        const date = new Date(dateKey);
-        const day = date.getDay(); // 0=Sun
-        const mondayOffset = day === 0 ? -6 : 1 - day;
-        const monday = new Date(date);
-        monday.setDate(date.getDate() + mondayOffset);
-        const weekKey =
-          `${monday.getFullYear()}-${String(monday.getMonth() + 1).padStart(2, '0')}-${String(monday.getDate()).padStart(2, '0')}` as DateKey;
-        if (!this.#npmPackageDownloadsPerWeek[weekKey]) {
-          this.#npmPackageDownloadsPerWeek[weekKey] = {};
-        }
-        this.#npmPackageDownloadsPerWeek[weekKey][pkg.details.name] =
-          (this.#npmPackageDownloadsPerWeek[weekKey][pkg.details.name] ?? 0) + count;
-
-        // Per-organization per-year downloads
-        if (!this.#npmOrganizationStatsPerYear[year]) {
-          this.#npmOrganizationStatsPerYear[year] = {};
-        }
-        if (!this.#npmOrganizationStatsPerYear[year][organizationName]) {
-          this.#npmOrganizationStatsPerYear[year][organizationName] = { downloads: 0, versions: 0, packages: 0 };
-        }
-        this.#npmOrganizationStatsPerYear[year][organizationName].downloads += count;
-
-        // Per-organization per-month-year downloads
-        if (!this.#npmOrganizationStatsPerMonthAndYear[monthYearKey]) {
-          this.#npmOrganizationStatsPerMonthAndYear[monthYearKey] = {};
-        }
-        if (!this.#npmOrganizationStatsPerMonthAndYear[monthYearKey][organizationName]) {
-          this.#npmOrganizationStatsPerMonthAndYear[monthYearKey][organizationName] = {
-            downloads: 0,
-            versions: 0,
-            packages: 0,
-          };
-        }
-        this.#npmOrganizationStatsPerMonthAndYear[monthYearKey][organizationName].downloads += count;
-      }
-
-      // Per-package per-year versions
-      for (const [key, count] of Object.entries(pkg.versionsPerDate)) {
-        if (!count) continue;
-        const dateKey = key as DateKey;
-        const [year, month] = splitDateKey(dateKey);
-        const monthYearKey = `${year}-${month}` satisfies MonthYearKey;
-
-        if (!this.#npmPackageStatsPerYear[year]) {
-          this.#npmPackageStatsPerYear[year] = {};
-        }
-        if (!this.#npmPackageStatsPerYear[year][pkg.details.name]) {
-          this.#npmPackageStatsPerYear[year][pkg.details.name] = { downloads: 0, versions: 0 };
-        }
-        this.#npmPackageStatsPerYear[year][pkg.details.name].versions += count;
-
-        // Per-package per-month-year versions
-        if (!this.#npmPackageStatsPerMonthAndYear[monthYearKey]) {
-          this.#npmPackageStatsPerMonthAndYear[monthYearKey] = {};
-        }
-        if (!this.#npmPackageStatsPerMonthAndYear[monthYearKey][pkg.details.name]) {
-          this.#npmPackageStatsPerMonthAndYear[monthYearKey][pkg.details.name] = { downloads: 0, versions: 0 };
-        }
-        this.#npmPackageStatsPerMonthAndYear[monthYearKey][pkg.details.name].versions += count;
-
-        if (!this.#npmOrganizationStatsPerYear[year]) {
-          this.#npmOrganizationStatsPerYear[year] = {};
-        }
-        if (!this.#npmOrganizationStatsPerYear[year][organizationName]) {
-          this.#npmOrganizationStatsPerYear[year][organizationName] = { downloads: 0, versions: 0, packages: 0 };
-        }
-        this.#npmOrganizationStatsPerYear[year][organizationName].versions += count;
-
-        // Per-organization per-month-year versions
-        if (!this.#npmOrganizationStatsPerMonthAndYear[monthYearKey]) {
-          this.#npmOrganizationStatsPerMonthAndYear[monthYearKey] = {};
-        }
-        if (!this.#npmOrganizationStatsPerMonthAndYear[monthYearKey][organizationName]) {
-          this.#npmOrganizationStatsPerMonthAndYear[monthYearKey][organizationName] = {
-            downloads: 0,
-            versions: 0,
-            packages: 0,
-          };
-        }
-        this.#npmOrganizationStatsPerMonthAndYear[monthYearKey][organizationName].versions += count;
-      }
-
-      const versionCount = Object.values(pkg.versionsPerDate).reduce<number>((acc, count) => acc + (count ?? 0), 0);
-
-      this.#npmPackageStats[pkg.details.name] = {
-        downloads: pkgDownloads,
-        versions: versionCount,
-      };
-      this.#npmOrganizationStats[organizationName].downloads += pkgDownloads;
-      this.#npmOrganizationStats[organizationName].versions += versionCount;
-      this.#npmTotalDownloads += pkgDownloads;
-      this.#npmTotalVersions += versionCount;
-
-      // Weekly downloads (last full week Mon-Sun)
-      let weeklyDownloads = 0;
-      for (const dateKey of lastFullWeekDateKeys) {
-        weeklyDownloads += (pkg.downloadsPerDate[dateKey] as number) ?? 0;
-      }
-      this.#npmPackageWeeklyDownloads[pkg.details.name] = weeklyDownloads;
-    }
-
-    // Count packages per org per year and per month-year
-    for (const pkg of this.#npmAccountStats.packages) {
-      const organizationName = pkg.details.name.includes('/')
-        ? pkg.details.name.split('/')[0]
-        : this.#npmAccountStats.user.username;
-
-      // Collect active months for this package
-      const activeMonths = new Set<MonthYearKey>();
-      for (const key of Object.keys(pkg.downloadsPerDate)) {
-        if (!pkg.downloadsPerDate[key as DateKey]) continue;
-        const [year, month] = splitDateKey(key as DateKey);
-        activeMonths.add(`${year}-${month}` satisfies MonthYearKey);
-      }
-      for (const key of Object.keys(pkg.versionsPerDate)) {
-        if (!pkg.versionsPerDate[key as DateKey]) continue;
-        const [year, month] = splitDateKey(key as DateKey);
-        activeMonths.add(`${year}-${month}` satisfies MonthYearKey);
-      }
-
-      // Count per year
-      for (const yearKey of Object.keys(this.#npmPackageStatsPerYear)) {
-        const year = Number(yearKey) as Year;
-        if (!this.#npmPackageStatsPerYear[year]?.[pkg.details.name]) continue;
-        if (!this.#npmOrganizationStatsPerYear[year]) {
-          this.#npmOrganizationStatsPerYear[year] = {};
-        }
-        if (!this.#npmOrganizationStatsPerYear[year][organizationName]) {
-          this.#npmOrganizationStatsPerYear[year][organizationName] = { downloads: 0, versions: 0, packages: 0 };
-        }
-        this.#npmOrganizationStatsPerYear[year][organizationName].packages += 1;
-      }
-
-      // Count per month-year
-      for (const monthYearKey of activeMonths) {
-        if (!this.#npmOrganizationStatsPerMonthAndYear[monthYearKey]) {
-          this.#npmOrganizationStatsPerMonthAndYear[monthYearKey] = {};
-        }
-        if (!this.#npmOrganizationStatsPerMonthAndYear[monthYearKey][organizationName]) {
-          this.#npmOrganizationStatsPerMonthAndYear[monthYearKey][organizationName] = {
-            downloads: 0,
-            versions: 0,
-            packages: 0,
-          };
-        }
-        this.#npmOrganizationStatsPerMonthAndYear[monthYearKey][organizationName].packages += 1;
-      }
-    }
-
-    // Calculate years
-    const allYearKeys = new Set<number>();
-    for (const key of Object.keys(this.#npmDownloadsPerYear)) {
-      allYearKeys.add(Number(key));
-    }
-    for (const key of Object.keys(this.#npmVersionsPerDate)) {
-      const [year] = splitDateKey(key as DateKey);
-      allYearKeys.add(year);
-    }
-    if (allYearKeys.size > 0) {
-      const minYear = Math.min(...allYearKeys);
-      this.#npmYears = Array.from({ length: new Date().getFullYear() - minYear + 1 }).map((_x, i) => minYear + i);
-    }
-
-    // Sort week keys
-    this.#npmWeekKeys = (Object.keys(this.#npmPackageDownloadsPerWeek) as DateKey[]).sort();
-  }
-
   async fetchData() {
     const startTime = Date.now();
     const [githubAccountStats, npmAccountStats] = await Promise.all([this.#fetchGithubStats(), this.#fetchNpmStats()]);
     this.#githubAccountStats = githubAccountStats;
     this.#npmAccountStats = npmAccountStats;
     this.#calculateGithubAccountStats();
-    this.#calculateNpmAccountStats();
+    this.#npm = aggregateNpmStats(npmAccountStats);
     const duration = Date.now() - startTime;
     if (duration < MIN_WAIT_DURATION) {
       await new Promise((resolve) => {
@@ -598,11 +318,11 @@ export class Data implements MetricsData {
   }
 
   get npmTotalDownloads() {
-    return this.#npmTotalDownloads;
+    return this.#npm.totalDownloads;
   }
 
   get npmTotalVersions() {
-    return this.#npmTotalVersions;
+    return this.#npm.totalVersions;
   }
 
   get npmPackageCount() {
@@ -610,79 +330,79 @@ export class Data implements MetricsData {
   }
 
   get npmOrganizationCount() {
-    return Object.keys(this.#npmOrganizationStats).length;
+    return Object.keys(this.#npm.organizationStats).length;
   }
 
   get npmDownloadsPerDate() {
-    return this.#npmDownloadsPerDate;
+    return this.#npm.downloadsPerDate;
   }
 
   get npmDownloadsPerYear() {
-    return this.#npmDownloadsPerYear;
+    return this.#npm.downloadsPerYear;
   }
 
   get npmDownloadsPerMonthAndYear() {
-    return this.#npmDownloadsPerMonthAndYear;
+    return this.#npm.downloadsPerMonthAndYear;
   }
 
   get npmVersionsPerDate() {
-    return this.#npmVersionsPerDate;
+    return this.#npm.versionsPerDate;
   }
 
   get npmVersionsPerHour() {
-    return this.#npmVersionsPerHour;
+    return this.#npm.versionsPerHour;
   }
 
   get npmVersionsPerWeekday() {
-    return this.#npmVersionsPerWeekday;
+    return this.#npm.versionsPerWeekday;
   }
 
   get npmPackageStats() {
-    return this.#npmPackageStats;
+    return this.#npm.packageStats;
   }
 
   get npmPackageStatsPerYear() {
-    return this.#npmPackageStatsPerYear;
+    return this.#npm.packageStatsPerYear;
   }
 
   get npmPackageStatsPerMonthAndYear() {
-    return this.#npmPackageStatsPerMonthAndYear;
+    return this.#npm.packageStatsPerMonthAndYear;
   }
 
   get npmPackageDownloadsPerWeek() {
-    return this.#npmPackageDownloadsPerWeek;
+    return this.#npm.packageDownloadsPerWeek;
   }
 
   get npmWeekKeys() {
-    return this.#npmWeekKeys;
+    return this.#npm.weekKeys;
   }
 
   get npmOrganizationPackages() {
-    return this.#npmOrganizationPackages;
+    return this.#npm.organizationPackages;
   }
 
   get npmPackageWeeklyDownloads() {
-    return this.#npmPackageWeeklyDownloads;
+    return this.#npm.packageWeeklyDownloads;
   }
 
   get npmOrganizationStats() {
-    return this.#npmOrganizationStats;
+    return this.#npm.organizationStats;
   }
 
   get npmOrganizationStatsPerYear() {
-    return this.#npmOrganizationStatsPerYear;
+    return this.#npm.organizationStatsPerYear;
   }
 
   get npmOrganizationStatsPerMonthAndYear() {
-    return this.#npmOrganizationStatsPerMonthAndYear;
+    return this.#npm.organizationStatsPerMonthAndYear;
   }
 
   get npmPackageDetails() {
-    return this.#npmPackageDetails;
+    return this.#npm.packageDetails;
   }
 
   get npmYears() {
-    return this.#npmYears;
+    return this.#npm.years;
   }
 
   get npmPackages(): PackageStats[] {
@@ -698,7 +418,7 @@ export class Data implements MetricsData {
       keys.length === 0 ? null : keys.reduce((a, b) => (a > b ? a : b));
 
     const githubLatest = maxKey(Object.keys(this.#githubCommitsPerDate));
-    const npmLatest = maxKey([...Object.keys(this.#npmDownloadsPerDate), ...Object.keys(this.#npmVersionsPerDate)]);
+    const npmLatest = maxKey([...Object.keys(this.#npm.downloadsPerDate), ...Object.keys(this.#npm.versionsPerDate)]);
 
     const candidates = [githubLatest, npmLatest].filter((key): key is string => key !== null);
     if (candidates.length === 0) return null;

--- a/src/models/LiveData.test.ts
+++ b/src/models/LiveData.test.ts
@@ -44,9 +44,7 @@ const NPM: NpmAccountStats = {
 };
 
 const client = (npm: NpmAccountStats | null) => ({
-  githubContributions: async () => CONTRIBUTIONS,
-  githubProfile: async () => PROFILE,
-  githubRepos: async () => REPOS,
+  github: async () => ({ profile: PROFILE, repos: REPOS, contributions: CONTRIBUTIONS }),
   npmStats: async () => {
     if (!npm) throw new Error('no npm');
     return npm;

--- a/src/models/LiveData.test.ts
+++ b/src/models/LiveData.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { GithubContributions, GithubProfile, GithubRepo } from '@/live/metricsApi';
+import { LiveData } from '@/models/LiveData';
+import type { AccountStats as NpmAccountStats } from '@/types/NpmStats';
+
+const CONTRIBUTIONS: GithubContributions = {
+  total: { '2023': 3, '2024': 6 },
+  contributions: [
+    { date: '2023-05-10', count: 3, level: 2 }, // Wednesday
+    { date: '2024-01-02', count: 2, level: 1 }, // Tuesday
+    { date: '2024-01-03', count: 0, level: 0 },
+    { date: '2024-12-31', count: 4, level: 3 }, // Tuesday
+  ],
+};
+
+const PROFILE: GithubProfile = {
+  name: 'Octo Cat',
+  username: 'octocat',
+  bio: 'hi',
+  avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+  url: 'https://github.com/octocat',
+  followerCount: 12,
+  followingCount: 3,
+  organizations: [],
+};
+
+const REPOS: GithubRepo[] = [
+  { name: 'a', url: 'u/a', description: 'd', language: 'TypeScript', stargazerCount: 5, forkCount: 1, isFork: false },
+  { name: 'b', url: 'u/b', description: '', language: 'TypeScript', stargazerCount: 2, forkCount: 0, isFork: false },
+  { name: 'c', url: 'u/c', description: '', language: 'Ruby', stargazerCount: 0, forkCount: 0, isFork: true },
+  { name: 'd', url: 'u/d', description: '', language: null, stargazerCount: 0, forkCount: 0, isFork: false },
+];
+
+const NPM: NpmAccountStats = {
+  user: { username: 'octocat', versionsPerDate: { '2024-01-02': 1 }, versionsPerHour: { 'Tue, 08': 1 } },
+  packages: [
+    {
+      details: { name: 'alpha', description: '', latestVersion: '1.0.0', license: 'MIT', keywords: [], links: {} },
+      downloadsPerDate: { '2024-01-10': 10 },
+      versionsPerDate: { '2024-01-02': 1 },
+      versionsPerHour: { 'Tue, 08': 1 },
+    },
+  ],
+};
+
+const client = (npm: NpmAccountStats | null) => ({
+  githubContributions: async () => CONTRIBUTIONS,
+  githubProfile: async () => PROFILE,
+  githubRepos: async () => REPOS,
+  npmStats: async () => {
+    if (!npm) throw new Error('no npm');
+    return npm;
+  },
+});
+
+describe('LiveData', () => {
+  it('aggregates contributions into the MetricsData getters', async () => {
+    const data = new LiveData('octocat', client(NPM), 0);
+    await data.fetchData();
+
+    expect(data.githubUser?.name).toBe('Octo Cat');
+    expect(data.githubUser?.followerCount).toBe(12);
+
+    expect(data.githubCommitStatTotals.commitCount).toBe(9);
+    expect(data.githubCommitsPerDate['2023-05-10']?.commitCount).toBe(3);
+    expect(data.githubCommitsPerDate['2024-01-03']).toBeUndefined(); // zero days skipped
+    expect(data.githubCommitsPerYear[2024]?.commitCount).toBe(6);
+    expect(data.githubCommitsPerMonthAndYear['2024-01']?.commitCount).toBe(2);
+    expect(data.githubCommitsPerMonth['01']?.commitCount).toBe(2);
+    expect(data.githubCommitStatsPerWeekday.Wed?.commitCount).toBe(3);
+    expect(data.githubCommitStatsPerWeekday.Tue?.commitCount).toBe(6);
+    expect(data.githubYears).toEqual(
+      Array.from({ length: new Date().getFullYear() - 2023 + 1 }).map((_x, i) => 2023 + i),
+    );
+    expect(data.githubCommitsPerYearAndRepository[2024]?.Contributions?.commitCount).toBe(6);
+
+    // repos -> public repositories + languages weighted by repo count
+    expect(Object.keys(data.githubPublicRepositories)).toEqual(['a', 'b', 'c', 'd']);
+    expect(data.githubCommitsPerLanguage).toEqual({ TypeScript: 2, Ruby: 1 });
+    expect(data.githubCommitStatTotals.publicCommitCount).toBe(3); // language denominator
+
+    expect(data.latestDataDate?.getFullYear()).toBe(2024);
+  });
+
+  it('exposes npm aggregates when packages exist', async () => {
+    const data = new LiveData('octocat', client(NPM), 0);
+    await data.fetchData();
+    expect(data.hasNpmData).toBe(true);
+    expect(data.npmUsername).toBe('octocat');
+    expect(data.npmTotalDownloads).toBe(10);
+    expect(data.npmPackageCount).toBe(1);
+  });
+
+  it('tolerates npm failure', async () => {
+    const data = new LiveData('octocat', client(null), 0);
+    await data.fetchData();
+    expect(data.hasNpmData).toBe(false);
+    expect(data.npmPackageCount).toBe(0);
+  });
+});

--- a/src/models/LiveData.ts
+++ b/src/models/LiveData.ts
@@ -1,0 +1,261 @@
+import { WEEKDAYS } from '@/constants';
+import type { GithubContributions, GithubProfile, GithubRepo } from '@/live/metricsApi';
+import { MetricsApiClient } from '@/live/metricsApi';
+import { EMPTY_COMMIT_STATS, MIN_WAIT_DURATION } from '@/models/Data';
+import type { MetricsData } from '@/models/MetricsData';
+import { aggregateNpmStats, emptyNpmAggregates, type NpmAggregates } from '@/models/npmAggregates';
+import type { MonthYearKey, PrivatePublicCommitStats } from '@/types/ComponentStats';
+import type { DateKey, Month, PublicRepositoryDetails, UserStats, Weekday, Year } from '@/types/GitHubStats';
+import type { AccountStats as NpmAccountStats } from '@/types/NpmStats';
+import { splitDateKey } from '@/util/recordKey';
+import { waitRemainder } from '@/util/timing';
+
+export type LiveApi = Pick<MetricsApiClient, 'githubContributions' | 'githubProfile' | 'githubRepos' | 'npmStats'>;
+
+/** Live-mode implementation of MetricsData backed by a hosted metrics-api-server.
+ *  Semantics: counts are GitHub *contributions* (not commits); everything is public;
+ *  additions/deletions/changedFiles stay 0. */
+export class LiveData implements MetricsData {
+  #username: string;
+  #client: LiveApi;
+  #minWait: number;
+
+  #githubUser: UserStats | null = null;
+  #commitsPerLanguage: Record<string, number> = {};
+  #statTotals: PrivatePublicCommitStats = { ...EMPTY_COMMIT_STATS };
+  #statsPerWeekday: Partial<Record<Weekday, PrivatePublicCommitStats>> = {};
+  #commitsPerDate: Partial<Record<DateKey, PrivatePublicCommitStats>> = {};
+  #commitsPerYear: Partial<Record<Year, PrivatePublicCommitStats>> = {};
+  #commitsPerMonthAndYear: Partial<Record<MonthYearKey, PrivatePublicCommitStats>> = {};
+  #commitsPerMonth: Partial<Record<Month, PrivatePublicCommitStats>> = {};
+  #commitsPerYearAndRepository: Partial<Record<Year, Record<string, PrivatePublicCommitStats>>> = {};
+  #publicRepositories: Record<string, PublicRepositoryDetails> = {};
+  #years: Year[] = [];
+  #latestDataDate: Date | null = null;
+
+  #npm: NpmAggregates = emptyNpmAggregates();
+  #npmAccountStats: NpmAccountStats | null = null;
+
+  constructor(username: string, client: LiveApi = new MetricsApiClient(), minWait = MIN_WAIT_DURATION) {
+    this.#username = username;
+    this.#client = client;
+    this.#minWait = minWait;
+  }
+
+  async fetchData(): Promise<void> {
+    const startTime = Date.now();
+    const [contributions, profile, repos, npmStats] = await Promise.all([
+      this.#client.githubContributions(this.#username),
+      this.#client.githubProfile(this.#username),
+      this.#client.githubRepos(this.#username),
+      this.#client.npmStats(this.#username.toLowerCase()).catch(() => null),
+    ]);
+    this.#applyGithub(contributions, profile, repos);
+    if (npmStats && npmStats.packages.length > 0) {
+      this.#npmAccountStats = npmStats;
+      this.#npm = aggregateNpmStats(npmStats);
+    }
+    await waitRemainder(startTime, this.#minWait);
+  }
+
+  #add<K extends string | number>(target: Partial<Record<K, PrivatePublicCommitStats>>, key: K, count: number): void {
+    const stats = target[key] ?? { ...EMPTY_COMMIT_STATS };
+    stats.commitCount += count;
+    stats.publicCommitCount += count;
+    target[key] = stats;
+  }
+
+  #applyGithub(contributions: GithubContributions, profile: GithubProfile, repos: GithubRepo[]): void {
+    this.#githubUser = {
+      name: profile.name,
+      username: profile.username,
+      bio: profile.bio,
+      avatarUrl: profile.avatarUrl,
+      url: profile.url,
+      gistCount: 0,
+      followerCount: profile.followerCount,
+      followingCount: profile.followingCount,
+      commentsPerDate: {},
+      commentsPerHour: {},
+    };
+
+    for (const repo of repos) {
+      this.#publicRepositories[repo.name] = {
+        name: repo.name,
+        url: repo.url,
+        languages: repo.language ? [repo.language] : [],
+        description: repo.description,
+        stargazerCount: repo.stargazerCount,
+        forkCount: repo.forkCount,
+      };
+      if (repo.language) {
+        this.#commitsPerLanguage[repo.language] = (this.#commitsPerLanguage[repo.language] ?? 0) + 1;
+      }
+    }
+
+    let totalContributions = 0;
+    for (const day of contributions.contributions) {
+      if (day.count === 0) continue;
+      totalContributions += day.count;
+      const dateKey = day.date as DateKey;
+      const [year, month] = splitDateKey(dateKey);
+      const monthYearKey: MonthYearKey = `${year}-${month}`;
+      const weekday = WEEKDAYS[new Date(`${day.date}T00:00:00`).getDay()];
+
+      this.#add(this.#commitsPerDate, dateKey, day.count);
+      this.#add(this.#commitsPerYear, year, day.count);
+      this.#add(this.#commitsPerMonthAndYear, monthYearKey, day.count);
+      this.#add(this.#commitsPerMonth, month, day.count);
+      this.#add(this.#statsPerWeekday, weekday, day.count);
+
+      this.#commitsPerYearAndRepository[year] ??= {};
+      this.#add(this.#commitsPerYearAndRepository[year], 'Contributions', day.count);
+    }
+
+    // publicCommitCount doubles as the denominator for the UserCard language shares
+    // (languages are weighted by repo count in live mode — there is no commit data).
+    this.#statTotals = {
+      ...EMPTY_COMMIT_STATS,
+      commitCount: totalContributions,
+      publicCommitCount: Object.values(this.#commitsPerLanguage).reduce((sum, count) => sum + count, 0),
+    };
+
+    const years = Object.keys(contributions.total)
+      .map(Number)
+      .filter(Number.isInteger)
+      .sort((a, b) => a - b);
+    if (years.length > 0) {
+      const minYear = years[0];
+      this.#years = Array.from({ length: new Date().getFullYear() - minYear + 1 }).map((_x, i) => minYear + i);
+    }
+
+    const activeDates = contributions.contributions.filter((day) => day.count > 0);
+    const lastActive = activeDates[activeDates.length - 1];
+    this.#latestDataDate = lastActive ? new Date(`${lastActive.date}T00:00:00`) : null;
+  }
+
+  // GitHub getters
+  get githubUser() {
+    return this.#githubUser;
+  }
+  get githubCommitsPerLanguage() {
+    return this.#commitsPerLanguage;
+  }
+  get githubCommitStatTotals() {
+    return this.#statTotals;
+  }
+  get githubCommitStatsPerHour() {
+    return {};
+  }
+  get githubCommitStatsPerWeekday() {
+    return this.#statsPerWeekday;
+  }
+  get githubCommitsPerRepository() {
+    return {};
+  }
+  get githubCommitsPerDate() {
+    return this.#commitsPerDate;
+  }
+  get githubCommitsPerYear() {
+    return this.#commitsPerYear;
+  }
+  get githubCommitsPerYearAndRepository() {
+    return this.#commitsPerYearAndRepository;
+  }
+  get githubCommitsPerMonth() {
+    return this.#commitsPerMonth;
+  }
+  get githubLanguagesPerYear() {
+    return {};
+  }
+  get githubCommitsPerMonthAndYear() {
+    return this.#commitsPerMonthAndYear;
+  }
+  get githubYears() {
+    return this.#years;
+  }
+  get githubPublicRepositories() {
+    return this.#publicRepositories;
+  }
+
+  // npm getters (delegating to the shared aggregates)
+  get hasNpmData() {
+    return (this.#npmAccountStats?.packages.length ?? 0) > 0;
+  }
+  get npmUsername() {
+    return this.#npmAccountStats?.user.username ?? '';
+  }
+  get npmTotalDownloads() {
+    return this.#npm.totalDownloads;
+  }
+  get npmTotalVersions() {
+    return this.#npm.totalVersions;
+  }
+  get npmPackageCount() {
+    return this.#npmAccountStats?.packages.length ?? 0;
+  }
+  get npmOrganizationCount() {
+    return Object.keys(this.#npm.organizationStats).length;
+  }
+  get npmDownloadsPerDate() {
+    return this.#npm.downloadsPerDate;
+  }
+  get npmDownloadsPerYear() {
+    return this.#npm.downloadsPerYear;
+  }
+  get npmDownloadsPerMonthAndYear() {
+    return this.#npm.downloadsPerMonthAndYear;
+  }
+  get npmVersionsPerDate() {
+    return this.#npm.versionsPerDate;
+  }
+  get npmVersionsPerHour() {
+    return this.#npm.versionsPerHour;
+  }
+  get npmVersionsPerWeekday() {
+    return this.#npm.versionsPerWeekday;
+  }
+  get npmPackageStats() {
+    return this.#npm.packageStats;
+  }
+  get npmPackageStatsPerYear() {
+    return this.#npm.packageStatsPerYear;
+  }
+  get npmPackageStatsPerMonthAndYear() {
+    return this.#npm.packageStatsPerMonthAndYear;
+  }
+  get npmPackageDownloadsPerWeek() {
+    return this.#npm.packageDownloadsPerWeek;
+  }
+  get npmWeekKeys() {
+    return this.#npm.weekKeys;
+  }
+  get npmOrganizationPackages() {
+    return this.#npm.organizationPackages;
+  }
+  get npmPackageWeeklyDownloads() {
+    return this.#npm.packageWeeklyDownloads;
+  }
+  get npmOrganizationStats() {
+    return this.#npm.organizationStats;
+  }
+  get npmOrganizationStatsPerYear() {
+    return this.#npm.organizationStatsPerYear;
+  }
+  get npmOrganizationStatsPerMonthAndYear() {
+    return this.#npm.organizationStatsPerMonthAndYear;
+  }
+  get npmPackageDetails() {
+    return this.#npm.packageDetails;
+  }
+  get npmYears() {
+    return this.#npm.years;
+  }
+  get npmPackages() {
+    return this.#npmAccountStats?.packages ?? [];
+  }
+
+  get latestDataDate() {
+    return this.#latestDataDate;
+  }
+}

--- a/src/models/LiveData.ts
+++ b/src/models/LiveData.ts
@@ -10,7 +10,7 @@ import type { AccountStats as NpmAccountStats } from '@/types/NpmStats';
 import { splitDateKey } from '@/util/recordKey';
 import { waitRemainder } from '@/util/timing';
 
-export type LiveApi = Pick<MetricsApiClient, 'githubContributions' | 'githubProfile' | 'githubRepos' | 'npmStats'>;
+export type LiveApi = Pick<MetricsApiClient, 'github' | 'npmStats'>;
 
 /** Live-mode implementation of MetricsData backed by a hosted metrics-api-server.
  *  Semantics: counts are GitHub *contributions* (not commits); everything is public;
@@ -44,13 +44,11 @@ export class LiveData implements MetricsData {
 
   async fetchData(): Promise<void> {
     const startTime = Date.now();
-    const [contributions, profile, repos, npmStats] = await Promise.all([
-      this.#client.githubContributions(this.#username),
-      this.#client.githubProfile(this.#username),
-      this.#client.githubRepos(this.#username),
+    const [github, npmStats] = await Promise.all([
+      this.#client.github(this.#username),
       this.#client.npmStats(this.#username.toLowerCase()).catch(() => null),
     ]);
-    this.#applyGithub(contributions, profile, repos);
+    this.#applyGithub(github.contributions, github.profile, github.repos);
     if (npmStats && npmStats.packages.length > 0) {
       this.#npmAccountStats = npmStats;
       this.#npm = aggregateNpmStats(npmStats);

--- a/src/models/MetricsData.ts
+++ b/src/models/MetricsData.ts
@@ -1,0 +1,57 @@
+import type {
+  MonthYearKey,
+  NpmOrganizationStats,
+  NpmPackageStats,
+  PrivatePublicCommitStats,
+} from '@/types/ComponentStats';
+import type { DateKey, HourKey, Month, PublicRepositoryDetails, UserStats, Weekday, Year } from '@/types/GitHubStats';
+import type { PackageDetails, PackageStats } from '@/types/NpmStats';
+
+/** Getter surface the cards render from — implemented by Data (stats repos) and LiveData (metrics-api). */
+export interface MetricsData {
+  fetchData(): Promise<void>;
+  readonly hasNpmData: boolean;
+  readonly latestDataDate: Date | null;
+
+  // GitHub
+  readonly githubUser: UserStats | null;
+  readonly githubCommitsPerLanguage: Record<string, number>;
+  readonly githubCommitStatTotals: PrivatePublicCommitStats;
+  readonly githubCommitStatsPerHour: Partial<Record<HourKey, PrivatePublicCommitStats>>;
+  readonly githubCommitStatsPerWeekday: Partial<Record<Weekday, PrivatePublicCommitStats>>;
+  readonly githubCommitsPerRepository: Record<string, PrivatePublicCommitStats>;
+  readonly githubCommitsPerDate: Partial<Record<DateKey, PrivatePublicCommitStats>>;
+  readonly githubCommitsPerYear: Partial<Record<Year, PrivatePublicCommitStats>>;
+  readonly githubCommitsPerYearAndRepository: Partial<Record<Year, Record<string, PrivatePublicCommitStats>>>;
+  readonly githubCommitsPerMonth: Partial<Record<Month, PrivatePublicCommitStats>>;
+  readonly githubLanguagesPerYear: Partial<Record<Year, Record<string, number>>>;
+  readonly githubCommitsPerMonthAndYear: Partial<Record<MonthYearKey, PrivatePublicCommitStats>>;
+  readonly githubYears: Year[];
+  readonly githubPublicRepositories: Record<string, PublicRepositoryDetails>;
+
+  // npm
+  readonly npmUsername: string;
+  readonly npmTotalDownloads: number;
+  readonly npmTotalVersions: number;
+  readonly npmPackageCount: number;
+  readonly npmOrganizationCount: number;
+  readonly npmDownloadsPerDate: Partial<Record<DateKey, number>>;
+  readonly npmDownloadsPerYear: Partial<Record<Year, number>>;
+  readonly npmDownloadsPerMonthAndYear: Partial<Record<MonthYearKey, number>>;
+  readonly npmVersionsPerDate: Partial<Record<DateKey, number>>;
+  readonly npmVersionsPerHour: Partial<Record<HourKey, number>>;
+  readonly npmVersionsPerWeekday: Partial<Record<Weekday, number>>;
+  readonly npmPackageStats: Record<string, NpmPackageStats>;
+  readonly npmPackageStatsPerYear: Partial<Record<Year, Record<string, NpmPackageStats>>>;
+  readonly npmPackageStatsPerMonthAndYear: Partial<Record<MonthYearKey, Record<string, NpmPackageStats>>>;
+  readonly npmPackageDownloadsPerWeek: Record<string, Record<string, number>>;
+  readonly npmWeekKeys: DateKey[];
+  readonly npmOrganizationPackages: Record<string, string[]>;
+  readonly npmPackageWeeklyDownloads: Record<string, number>;
+  readonly npmOrganizationStats: Record<string, NpmOrganizationStats>;
+  readonly npmOrganizationStatsPerYear: Partial<Record<Year, Record<string, NpmOrganizationStats>>>;
+  readonly npmOrganizationStatsPerMonthAndYear: Partial<Record<MonthYearKey, Record<string, NpmOrganizationStats>>>;
+  readonly npmPackageDetails: Record<string, PackageDetails>;
+  readonly npmYears: Year[];
+  readonly npmPackages: PackageStats[];
+}

--- a/src/models/npmAggregates.test.ts
+++ b/src/models/npmAggregates.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateNpmStats, emptyNpmAggregates } from '@/models/npmAggregates';
+import type { AccountStats } from '@/types/NpmStats';
+
+const STATS: AccountStats = {
+  user: {
+    username: 'octocat',
+    versionsPerDate: { '2024-01-02': 1, '2023-05-10': 2 },
+    versionsPerHour: { 'Tue, 08': 1, 'Wed, 12': 1, 'Wed, 18': 1 },
+  },
+  packages: [
+    {
+      details: {
+        name: 'alpha',
+        description: 'a',
+        latestVersion: '2.0.0',
+        license: 'MIT',
+        keywords: [],
+        links: {},
+      },
+      downloadsPerDate: { '2024-01-10': 10, '2024-02-11': 5 },
+      versionsPerDate: { '2023-05-10': 2, '2024-01-02': 1 },
+      versionsPerHour: { 'Wed, 12': 1, 'Wed, 18': 1, 'Tue, 08': 1 },
+    },
+    {
+      details: {
+        name: '@org/beta',
+        description: 'b',
+        latestVersion: '0.1.0',
+        license: 'MIT',
+        keywords: [],
+        links: {},
+      },
+      downloadsPerDate: { '2024-01-10': 3 },
+      versionsPerDate: { '2024-06-01': 1 },
+      versionsPerHour: { 'Sat, 00': 1 },
+    },
+  ],
+};
+
+describe('aggregateNpmStats', () => {
+  const agg = aggregateNpmStats(STATS);
+
+  it('totals downloads and versions', () => {
+    expect(agg.totalDownloads).toBe(18);
+    expect(agg.totalVersions).toBe(4);
+  });
+
+  it('aggregates downloads per date/year', () => {
+    expect(agg.downloadsPerDate).toEqual({ '2024-01-10': 13, '2024-02-11': 5 });
+    expect(agg.downloadsPerYear[2024]).toBe(18);
+  });
+
+  it('groups organizations (scope prefix, else username)', () => {
+    expect(agg.organizationStats.octocat).toEqual({ downloads: 15, versions: 3, packages: 1 });
+    expect(agg.organizationStats['@org']).toEqual({ downloads: 3, versions: 1, packages: 1 });
+    expect(agg.organizationPackages).toEqual({ octocat: ['alpha'], '@org': ['@org/beta'] });
+  });
+
+  it('keeps per-package stats and details', () => {
+    expect(agg.packageStats.alpha).toEqual({ downloads: 15, versions: 3 });
+    expect(agg.packageDetails['@org/beta'].name).toBe('@org/beta');
+  });
+
+  it('derives years from downloads and versions', () => {
+    expect(agg.years[0]).toBe(2023);
+    expect(agg.years[agg.years.length - 1]).toBe(new Date().getFullYear());
+  });
+
+  it('emptyNpmAggregates matches the aggregate shape with empty values', () => {
+    const empty = emptyNpmAggregates();
+    expect(Object.keys(empty).sort()).toEqual(Object.keys(agg).sort());
+    expect(empty.totalDownloads).toBe(0);
+    expect(empty.years).toEqual([]);
+  });
+});

--- a/src/models/npmAggregates.ts
+++ b/src/models/npmAggregates.ts
@@ -1,0 +1,304 @@
+import type { MonthYearKey, NpmOrganizationStats, NpmPackageStats } from '@/types/ComponentStats';
+import type { DateKey, HourKey, Weekday, Year } from '@/types/GitHubStats';
+import type { AccountStats, PackageDetails } from '@/types/NpmStats';
+import { splitDateKey, splitHourKey } from '@/util/recordKey';
+
+export interface NpmAggregates {
+  totalDownloads: number;
+  totalVersions: number;
+  downloadsPerDate: Partial<Record<DateKey, number>>;
+  downloadsPerYear: Partial<Record<Year, number>>;
+  downloadsPerMonthAndYear: Partial<Record<MonthYearKey, number>>;
+  versionsPerDate: Partial<Record<DateKey, number>>;
+  versionsPerHour: Partial<Record<HourKey, number>>;
+  versionsPerWeekday: Partial<Record<Weekday, number>>;
+  packageStats: Record<string, NpmPackageStats>;
+  packageStatsPerYear: Partial<Record<Year, Record<string, NpmPackageStats>>>;
+  packageStatsPerMonthAndYear: Partial<Record<MonthYearKey, Record<string, NpmPackageStats>>>;
+  organizationStats: Record<string, NpmOrganizationStats>;
+  organizationStatsPerYear: Partial<Record<Year, Record<string, NpmOrganizationStats>>>;
+  organizationStatsPerMonthAndYear: Partial<Record<MonthYearKey, Record<string, NpmOrganizationStats>>>;
+  organizationPackages: Record<string, string[]>;
+  packageWeeklyDownloads: Record<string, number>;
+  packageDownloadsPerWeek: Record<string, Record<string, number>>; // weekKey -> { pkgName -> downloads }
+  weekKeys: DateKey[];
+  packageDetails: Record<string, PackageDetails>;
+  years: Year[];
+}
+
+export const emptyNpmAggregates = (): NpmAggregates => ({
+  totalDownloads: 0,
+  totalVersions: 0,
+  downloadsPerDate: {},
+  downloadsPerYear: {},
+  downloadsPerMonthAndYear: {},
+  versionsPerDate: {},
+  versionsPerHour: {},
+  versionsPerWeekday: {},
+  packageStats: {},
+  packageStatsPerYear: {},
+  packageStatsPerMonthAndYear: {},
+  organizationStats: {},
+  organizationStatsPerYear: {},
+  organizationStatsPerMonthAndYear: {},
+  organizationPackages: {},
+  packageWeeklyDownloads: {},
+  packageDownloadsPerWeek: {},
+  weekKeys: [],
+  packageDetails: {},
+  years: [],
+});
+
+export const aggregateNpmStats = (stats: AccountStats): NpmAggregates => {
+  const out = emptyNpmAggregates();
+
+  // Compute last full week (Mon-Sun) date keys
+  const today = new Date();
+  const dayOfWeek = today.getDay(); // 0=Sun, 1=Mon, ...
+  const lastSunday = new Date(today);
+  lastSunday.setDate(today.getDate() - (dayOfWeek === 0 ? 7 : dayOfWeek));
+  const lastMonday = new Date(lastSunday);
+  lastMonday.setDate(lastSunday.getDate() - 6);
+  const lastFullWeekDateKeys: DateKey[] = [];
+  for (const d = new Date(lastMonday); d <= lastSunday; d.setDate(d.getDate() + 1)) {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    lastFullWeekDateKeys.push(`${y}-${m}-${day}` as DateKey);
+  }
+
+  // Aggregate user-level versions (for daytime/heatmap charts)
+  for (const [key, count] of Object.entries(stats.user.versionsPerDate)) {
+    if (!count) continue;
+    const dateKey = key as DateKey;
+    const [year] = splitDateKey(dateKey);
+
+    out.versionsPerDate[dateKey] = (out.versionsPerDate[dateKey] ?? 0) + count;
+
+    // Year
+    out.downloadsPerYear[year] = out.downloadsPerYear[year] ?? 0;
+  }
+
+  for (const [key, count] of Object.entries(stats.user.versionsPerHour)) {
+    if (!count) continue;
+    const hourKey = key as HourKey;
+    const [weekday] = splitHourKey(hourKey);
+
+    out.versionsPerHour[hourKey] = (out.versionsPerHour[hourKey] ?? 0) + count;
+    out.versionsPerWeekday[weekday] = (out.versionsPerWeekday[weekday] ?? 0) + count;
+  }
+
+  // Aggregate per-package data
+  for (const pkg of stats.packages) {
+    out.packageDetails[pkg.details.name] = pkg.details;
+    const organizationName = pkg.details.name.includes('/') ? pkg.details.name.split('/')[0] : stats.user.username;
+    if (!out.organizationStats[organizationName]) {
+      out.organizationStats[organizationName] = {
+        downloads: 0,
+        versions: 0,
+        packages: 0,
+      };
+    }
+    out.organizationStats[organizationName].packages += 1;
+    if (!out.organizationPackages[organizationName]) {
+      out.organizationPackages[organizationName] = [];
+    }
+    out.organizationPackages[organizationName].push(pkg.details.name);
+
+    let pkgDownloads = 0;
+    for (const [key, count] of Object.entries(pkg.downloadsPerDate)) {
+      if (!count) continue;
+      const dateKey = key as DateKey;
+      const [year, month] = splitDateKey(dateKey);
+      const monthYearKey = `${year}-${month}` satisfies MonthYearKey;
+
+      pkgDownloads += count;
+      out.downloadsPerDate[dateKey] = (out.downloadsPerDate[dateKey] ?? 0) + count;
+      out.downloadsPerYear[year] = (out.downloadsPerYear[year] ?? 0) + count;
+      out.downloadsPerMonthAndYear[monthYearKey] = (out.downloadsPerMonthAndYear[monthYearKey] ?? 0) + count;
+
+      // Per-package per-year downloads
+      if (!out.packageStatsPerYear[year]) {
+        out.packageStatsPerYear[year] = {};
+      }
+      if (!out.packageStatsPerYear[year][pkg.details.name]) {
+        out.packageStatsPerYear[year][pkg.details.name] = { downloads: 0, versions: 0 };
+      }
+      out.packageStatsPerYear[year][pkg.details.name].downloads += count;
+
+      // Per-package per-month-year downloads
+      if (!out.packageStatsPerMonthAndYear[monthYearKey]) {
+        out.packageStatsPerMonthAndYear[monthYearKey] = {};
+      }
+      if (!out.packageStatsPerMonthAndYear[monthYearKey][pkg.details.name]) {
+        out.packageStatsPerMonthAndYear[monthYearKey][pkg.details.name] = { downloads: 0, versions: 0 };
+      }
+      out.packageStatsPerMonthAndYear[monthYearKey][pkg.details.name].downloads += count;
+
+      // Per-package per-week downloads
+      const date = new Date(dateKey);
+      const day = date.getDay(); // 0=Sun
+      const mondayOffset = day === 0 ? -6 : 1 - day;
+      const monday = new Date(date);
+      monday.setDate(date.getDate() + mondayOffset);
+      const weekKey =
+        `${monday.getFullYear()}-${String(monday.getMonth() + 1).padStart(2, '0')}-${String(monday.getDate()).padStart(2, '0')}` as DateKey;
+      if (!out.packageDownloadsPerWeek[weekKey]) {
+        out.packageDownloadsPerWeek[weekKey] = {};
+      }
+      out.packageDownloadsPerWeek[weekKey][pkg.details.name] =
+        (out.packageDownloadsPerWeek[weekKey][pkg.details.name] ?? 0) + count;
+
+      // Per-organization per-year downloads
+      if (!out.organizationStatsPerYear[year]) {
+        out.organizationStatsPerYear[year] = {};
+      }
+      if (!out.organizationStatsPerYear[year][organizationName]) {
+        out.organizationStatsPerYear[year][organizationName] = { downloads: 0, versions: 0, packages: 0 };
+      }
+      out.organizationStatsPerYear[year][organizationName].downloads += count;
+
+      // Per-organization per-month-year downloads
+      if (!out.organizationStatsPerMonthAndYear[monthYearKey]) {
+        out.organizationStatsPerMonthAndYear[monthYearKey] = {};
+      }
+      if (!out.organizationStatsPerMonthAndYear[monthYearKey][organizationName]) {
+        out.organizationStatsPerMonthAndYear[monthYearKey][organizationName] = {
+          downloads: 0,
+          versions: 0,
+          packages: 0,
+        };
+      }
+      out.organizationStatsPerMonthAndYear[monthYearKey][organizationName].downloads += count;
+    }
+
+    // Per-package per-year versions
+    for (const [key, count] of Object.entries(pkg.versionsPerDate)) {
+      if (!count) continue;
+      const dateKey = key as DateKey;
+      const [year, month] = splitDateKey(dateKey);
+      const monthYearKey = `${year}-${month}` satisfies MonthYearKey;
+
+      if (!out.packageStatsPerYear[year]) {
+        out.packageStatsPerYear[year] = {};
+      }
+      if (!out.packageStatsPerYear[year][pkg.details.name]) {
+        out.packageStatsPerYear[year][pkg.details.name] = { downloads: 0, versions: 0 };
+      }
+      out.packageStatsPerYear[year][pkg.details.name].versions += count;
+
+      // Per-package per-month-year versions
+      if (!out.packageStatsPerMonthAndYear[monthYearKey]) {
+        out.packageStatsPerMonthAndYear[monthYearKey] = {};
+      }
+      if (!out.packageStatsPerMonthAndYear[monthYearKey][pkg.details.name]) {
+        out.packageStatsPerMonthAndYear[monthYearKey][pkg.details.name] = { downloads: 0, versions: 0 };
+      }
+      out.packageStatsPerMonthAndYear[monthYearKey][pkg.details.name].versions += count;
+
+      if (!out.organizationStatsPerYear[year]) {
+        out.organizationStatsPerYear[year] = {};
+      }
+      if (!out.organizationStatsPerYear[year][organizationName]) {
+        out.organizationStatsPerYear[year][organizationName] = { downloads: 0, versions: 0, packages: 0 };
+      }
+      out.organizationStatsPerYear[year][organizationName].versions += count;
+
+      // Per-organization per-month-year versions
+      if (!out.organizationStatsPerMonthAndYear[monthYearKey]) {
+        out.organizationStatsPerMonthAndYear[monthYearKey] = {};
+      }
+      if (!out.organizationStatsPerMonthAndYear[monthYearKey][organizationName]) {
+        out.organizationStatsPerMonthAndYear[monthYearKey][organizationName] = {
+          downloads: 0,
+          versions: 0,
+          packages: 0,
+        };
+      }
+      out.organizationStatsPerMonthAndYear[monthYearKey][organizationName].versions += count;
+    }
+
+    const versionCount = Object.values(pkg.versionsPerDate).reduce<number>((acc, count) => acc + (count ?? 0), 0);
+
+    out.packageStats[pkg.details.name] = {
+      downloads: pkgDownloads,
+      versions: versionCount,
+    };
+    out.organizationStats[organizationName].downloads += pkgDownloads;
+    out.organizationStats[organizationName].versions += versionCount;
+    out.totalDownloads += pkgDownloads;
+    out.totalVersions += versionCount;
+
+    // Weekly downloads (last full week Mon-Sun)
+    let weeklyDownloads = 0;
+    for (const dateKey of lastFullWeekDateKeys) {
+      weeklyDownloads += (pkg.downloadsPerDate[dateKey] as number) ?? 0;
+    }
+    out.packageWeeklyDownloads[pkg.details.name] = weeklyDownloads;
+  }
+
+  // Count packages per org per year and per month-year
+  for (const pkg of stats.packages) {
+    const organizationName = pkg.details.name.includes('/') ? pkg.details.name.split('/')[0] : stats.user.username;
+
+    // Collect active months for this package
+    const activeMonths = new Set<MonthYearKey>();
+    for (const key of Object.keys(pkg.downloadsPerDate)) {
+      if (!pkg.downloadsPerDate[key as DateKey]) continue;
+      const [year, month] = splitDateKey(key as DateKey);
+      activeMonths.add(`${year}-${month}` satisfies MonthYearKey);
+    }
+    for (const key of Object.keys(pkg.versionsPerDate)) {
+      if (!pkg.versionsPerDate[key as DateKey]) continue;
+      const [year, month] = splitDateKey(key as DateKey);
+      activeMonths.add(`${year}-${month}` satisfies MonthYearKey);
+    }
+
+    // Count per year
+    for (const yearKey of Object.keys(out.packageStatsPerYear)) {
+      const year = Number(yearKey) as Year;
+      if (!out.packageStatsPerYear[year]?.[pkg.details.name]) continue;
+      if (!out.organizationStatsPerYear[year]) {
+        out.organizationStatsPerYear[year] = {};
+      }
+      if (!out.organizationStatsPerYear[year][organizationName]) {
+        out.organizationStatsPerYear[year][organizationName] = { downloads: 0, versions: 0, packages: 0 };
+      }
+      out.organizationStatsPerYear[year][organizationName].packages += 1;
+    }
+
+    // Count per month-year
+    for (const monthYearKey of activeMonths) {
+      if (!out.organizationStatsPerMonthAndYear[monthYearKey]) {
+        out.organizationStatsPerMonthAndYear[monthYearKey] = {};
+      }
+      if (!out.organizationStatsPerMonthAndYear[monthYearKey][organizationName]) {
+        out.organizationStatsPerMonthAndYear[monthYearKey][organizationName] = {
+          downloads: 0,
+          versions: 0,
+          packages: 0,
+        };
+      }
+      out.organizationStatsPerMonthAndYear[monthYearKey][organizationName].packages += 1;
+    }
+  }
+
+  // Calculate years
+  const allYearKeys = new Set<number>();
+  for (const key of Object.keys(out.downloadsPerYear)) {
+    allYearKeys.add(Number(key));
+  }
+  for (const key of Object.keys(out.versionsPerDate)) {
+    const [year] = splitDateKey(key as DateKey);
+    allYearKeys.add(year);
+  }
+  if (allYearKeys.size > 0) {
+    const minYear = Math.min(...allYearKeys);
+    out.years = Array.from({ length: new Date().getFullYear() - minYear + 1 }).map((_x, i) => minYear + i);
+  }
+
+  // Sort week keys
+  out.weekKeys = (Object.keys(out.packageDownloadsPerWeek) as DateKey[]).sort();
+
+  return out;
+};

--- a/src/util/recordKey.test.ts
+++ b/src/util/recordKey.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getDateKeysForYear, isLeapYear, splitDateKey } from '@/util/recordKey';
+
+describe('recordKey', () => {
+  it('splits date keys', () => {
+    expect(splitDateKey('2024-03-02')).toEqual([2024, '03', '02']);
+  });
+  it('detects leap years', () => {
+    expect(isLeapYear(2024)).toBe(true);
+    expect(isLeapYear(2026)).toBe(false);
+    expect(isLeapYear(2000)).toBe(true);
+    expect(isLeapYear(1900)).toBe(false);
+  });
+  it('generates 366 keys for leap years', () => {
+    expect(getDateKeysForYear(2024)).toHaveLength(366);
+    expect(getDateKeysForYear(2026)).toHaveLength(365);
+  });
+});

--- a/src/util/route.test.ts
+++ b/src/util/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { parseLiveUser } from '@/util/route';
+
+describe('parseLiveUser', () => {
+  it('matches ~username paths', () => {
+    expect(parseLiveUser('/~slavadev')).toBe('slavadev');
+    expect(parseLiveUser('/~tamino-martinius/')).toBe('tamino-martinius');
+  });
+  it('returns null otherwise', () => {
+    expect(parseLiveUser('/')).toBe(null);
+    expect(parseLiveUser('/~')).toBe(null);
+    expect(parseLiveUser('/~-bad')).toBe(null);
+    expect(parseLiveUser('/~a/b')).toBe(null);
+    expect(parseLiveUser(`/~${'a'.repeat(40)}`)).toBe(null);
+  });
+});

--- a/src/util/route.ts
+++ b/src/util/route.ts
@@ -1,0 +1,4 @@
+const LIVE_ROUTE_RE = /^\/~([a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38})\/?$/;
+
+/** Extracts the GitHub username from a `/~username` path, or null for every other path. */
+export const parseLiveUser = (pathname: string): string | null => pathname.match(LIVE_ROUTE_RE)?.[1] ?? null;

--- a/src/util/timing.ts
+++ b/src/util/timing.ts
@@ -1,0 +1,8 @@
+/** Resolves once at least `minDuration` ms have passed since `startTime` (Date.now()-based). */
+export const waitRemainder = (startTime: number, minDuration: number): Promise<void> => {
+  const remaining = minDuration - (Date.now() - startTime);
+  if (remaining <= 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    setTimeout(resolve, remaining);
+  });
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: { '@': path.resolve(__dirname, './src') },
+  },
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `/~{githubUser}` routes that render live, public GitHub (and optionally npm) metrics for any GitHub username, fetched at request time from the [node-metrics-api](https://github.com/tamino-martinius/node-metrics-api) service — no build-time data required.
- The classic `/` dashboard (bundled/static data, "Commits" semantics, full card set) is **unchanged**.
- `dist/404.html` is generated as a copy of `dist/index.html` at build time so GitHub Pages serves the SPA shell for any `~username` deep link.

## metrics-api dependency

Live pages depend on a companion service, `tamino-martinius/node-metrics-api`, which scrapes public GitHub profile/contribution/repo data and aggregates npm registry stats behind four clean JSON endpoints (`/github/:user/profile`, `/github/:user/contributions`, `/github/:user/repos`, `/npm/:user`).

**Production status:** `metrics-api.tamino.dev` is not deployed yet — the Vercel project/DNS setup is a pending owner step from the node-metrics-api plan. Until that's done, live `~username` pages in production will hit the fetch failure path and show the "Live data is currently unavailable — please try again later" error state with a link back to `/`. This was verified directly (see below) by building without `VITE_METRICS_API_URL` and confirming the graceful error UI rather than a crash.

## Vendored client

`src/live/metricsApi.ts` is a small hand-written fetch client for the four metrics-api endpoints (reads `VITE_METRICS_API_URL`, defaults to `https://metrics-api.tamino.dev`). This is a temporary vendor copy — node-metrics-api already has a typed `metrics-api-client` package; once that package is published to npm, this file should be swapped for the real dependency (tracked as a follow-up, not in scope here).

## Contributions vs. commits semantics

Live mode has fundamentally different data than the classic bundled dashboard:
- Classic `/`: private+public **commit** stats scraped from a GitHub GraphQL export, with additions/deletions/changed-files detail.
- Live `~username`: public **contribution** counts (GitHub's public contribution graph) — additions/deletions/changed-files are unavailable and stay at 0, and there's no public/private split (everything is public by definition).

To avoid implying data that doesn't exist, live mode:
- Labels totals/heatmap as "Contributions" instead of "Commits".
- Hides cards that require commit-level detail: Daytime Chart, Weekday Chart (commit-type breakdown), Visibility Comparison, Timeline. It keeps: user card, Total Counts, Year Chart, Year Heatmap, Weekday Comparison, Followers, Popular Repos.
- Shows the npm tab only when the user actually has published npm packages (`hasNpmData`); npm fetch failures are swallowed (`.catch(() => null)`) so a slow/erroring npm lookup never blocks or breaks the GitHub-only render.
- Shows a "not found" state (with a back link) when the GitHub username doesn't exist, and an "unavailable" state for any other fetch failure.

## Verification

Since production isn't deployed, end-to-end verification ran the metrics-api service locally:

1. Added `scripts/dev-server.mjs` to the node-metrics-api repo (pushed separately, `tamino-martinius/node-metrics-api@main`) — a minimal `node:http` bridge that mirrors `vercel.json`'s rewrites over the four Vercel handlers, so they can be exercised without an actual Vercel deployment.
2. Built `metrics-api-server` and ran the dev server on `localhost:8787`; confirmed all four endpoints return real upstream data (GitHub profile/contributions/repos scraped live, npm stats aggregated live) and that an unknown GitHub user 404s.
3. Ran this frontend with `VITE_METRICS_API_URL=http://localhost:8787 npm run dev` and drove it with a real browser (Playwright):
   - `/~tamino-martinius`: user card, "144,611 Contributions" total-counts card, year chart, heatmap ("Contributions" label), weekday comparison, followers, popular repos all rendered with real data; header showed `~tamino-martinius`. This account has 228 npm packages (mostly scoped `@central-icons-*`), so the npm registry's per-package download-count endpoint rate-limited the request past the service's 240s backoff budget, and npm surfaced a 502 — handled gracefully: npm tab stayed hidden, GitHub content rendered normally, no crash.
   - `/~slavadev` (1 npm package): full GitHub tab **and** a populated npm tab (packages, downloads, publish daytime chart, org detail/timeline, version heatmap) — confirms the npm success path end-to-end.
   - `/~this-user-does-not-exist-xyz9`: "GitHub user ... was not found" state with a working "Back to metrics.tamino.dev" link.
   - `/`: classic dashboard unchanged — full card set, "Commits" labels, GitHub/npm tabs.
   - No unexpected console errors (only benign failed-fetch logs for the intentional 404/502 cases, and one pre-existing React key-prop warning on `/` unrelated to this change).
4. `npm run build && diff dist/index.html dist/404.html` → identical.
5. `npm run preview` (production build, no `VITE_METRICS_API_URL`): `/` loads fine; `/~slavadev` correctly falls back to the SPA shell and shows the "unavailable" error state (since it can't reach the not-yet-deployed `metrics-api.tamino.dev`), proving the failure path degrades gracefully rather than crashing.

## Test plan

- [x] `/~tamino-martinius` renders live GitHub data (real upstream, via local metrics-api dev server)
- [x] `/~slavadev` renders live GitHub + npm data (real upstream)
- [x] `/~this-user-does-not-exist-xyz9` shows the not-found state
- [x] `/` renders the unchanged classic dashboard
- [x] `npm run build` succeeds; `dist/404.html` equals `dist/index.html`
- [x] `npm run preview` production build degrades gracefully to the "unavailable" state when metrics-api is unreachable